### PR TITLE
Implement BodyPreV8 serialization

### DIFF
--- a/SatisfactorySaveNet.Tests/SaveSerializerTests.cs
+++ b/SatisfactorySaveNet.Tests/SaveSerializerTests.cs
@@ -1,7 +1,10 @@
 using SatisfactorySaveNet.Abstracts;
 using SatisfactorySaveNet.Abstracts.Model;
+using SatisfactorySaveNet.Abstracts.Maths.Vector;
 using FluentAssertions;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace SatisfactorySaveNet.Tests;
 
@@ -37,5 +40,64 @@ public class SaveSerializerTests
 
         result.Header.SaveVersion.Should().Be(save.Header.SaveVersion);
         result.Body.Should().BeOfType<BodyPreV8>();
+    }
+
+    [Test]
+    public void Serialize_Then_Deserialize_Roundtrip_With_Content()
+    {
+        var component = new ComponentObject
+        {
+            TypePath = "SomeComponent",
+            ObjectReference = new ObjectReference { LevelName = "Level", PathName = "Path" },
+            ParentActorName = "Parent"
+        };
+
+        var collectable = new ObjectReference { LevelName = "CLevel", PathName = "CPath" };
+
+        var actor = new ActorObject
+        {
+            TypePath = "SomeActor",
+            ObjectReference = new ObjectReference { LevelName = "ALevel", PathName = "APath" },
+            NeedTransform = 0,
+            Rotation = new Vector4(0, 0, 0, 0),
+            Position = new Vector3(0, 0, 0),
+            Scale = new Vector3(1, 1, 1),
+            PlacedInLevel = 1,
+            ParentObjectRoot = string.Empty,
+            ParentObjectName = string.Empty
+        };
+
+        var save = new SatisfactorySave
+        {
+            Header = new Header
+            {
+                HeaderVersion = 5,
+                SaveVersion = 10,
+                BuildVersion = 1,
+                SaveName = "Test",
+                MapName = "Map",
+                MapOptions = string.Empty,
+                SessionName = "Session",
+                PlayedSeconds = 0,
+                SaveDateTimeUtc = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                SessionVisibility = 0
+            },
+            Body = new BodyPreV8
+            {
+                Objects = new List<ComponentObject> { component, actor },
+                Collectables = new List<ObjectReference> { collectable }
+            }
+        };
+
+        var data = _serializer.Serialize(save);
+        var result = _serializer.Deserialize(data);
+
+        var body = result.Body.Should().BeOfType<BodyPreV8>().Subject;
+        body.Objects.Should().HaveCount(2);
+        body.Collectables.Should().HaveCount(1);
+
+        var deserializedComponent = body.Objects.First(o => o is not ActorObject);
+        deserializedComponent.Should().BeOfType<ComponentObject>().Which.ParentActorName.Should().Be("Parent");
+        body.Objects.OfType<ActorObject>().Single().PlacedInLevel.Should().Be(1);
     }
 }

--- a/SatisfactorySaveNet/BodySerializer.cs
+++ b/SatisfactorySaveNet/BodySerializer.cs
@@ -262,17 +262,107 @@ public class BodySerializer : IBodySerializer
 
     private void SerializePreV8(BinaryWriter writer, BodyPreV8 body)
     {
-        // Only support empty bodies for now
         writer.Write(body.Objects.Count);
-        if (body.Objects.Count != 0)
-            throw new NotSupportedException("Object serialization not implemented");
+        foreach (var obj in body.Objects)
+        {
+            SerializeObjectHeader(writer, obj);
+        }
 
         writer.Write(body.Objects.Count);
-        if (body.Objects.Count != 0)
-            throw new NotSupportedException("Object serialization not implemented");
+        foreach (var obj in body.Objects)
+        {
+            SerializeObject(writer, obj);
+        }
 
         writer.Write(body.Collectables.Count);
-        if (body.Collectables.Count != 0)
-            throw new NotSupportedException("Collectable serialization not implemented");
+        foreach (var collectable in body.Collectables)
+        {
+            SerializeObjectReference(writer, collectable);
+        }
+    }
+
+    private void SerializeObjectHeader(BinaryWriter writer, ComponentObject obj)
+    {
+        switch (obj)
+        {
+            case ActorObject actor:
+                writer.Write(ActorObject.TypeID);
+                _stringSerializer.Serialize(writer, actor.TypePath);
+                SerializeObjectReference(writer, actor.ObjectReference);
+                if (actor.Flags != null)
+                    throw new NotSupportedException("Actor flags serialization not implemented");
+                writer.Write(actor.NeedTransform);
+                writer.Write(actor.Rotation.X);
+                writer.Write(actor.Rotation.Y);
+                writer.Write(actor.Rotation.Z);
+                writer.Write(actor.Rotation.W);
+                writer.Write(actor.Position.X);
+                writer.Write(actor.Position.Y);
+                writer.Write(actor.Position.Z);
+                writer.Write(actor.Scale.X);
+                writer.Write(actor.Scale.Y);
+                writer.Write(actor.Scale.Z);
+                writer.Write(actor.PlacedInLevel);
+                break;
+            case ComponentObject component:
+                writer.Write(ComponentObject.TypeID);
+                _stringSerializer.Serialize(writer, component.TypePath);
+                SerializeObjectReference(writer, component.ObjectReference);
+                if (component.Flags != null)
+                    throw new NotSupportedException("Component flags serialization not implemented");
+                _stringSerializer.Serialize(writer, component.ParentActorName);
+                break;
+            default:
+                throw new NotSupportedException($"Object header serialization not implemented for type {obj.GetType().Name}");
+        }
+    }
+
+    private void SerializeObject(BinaryWriter writer, ComponentObject obj)
+    {
+        switch (obj)
+        {
+            case ActorObject actor:
+                if (actor.Properties.Count != 0)
+                    throw new NotSupportedException("Actor property serialization not implemented");
+                if (actor.ExtraData != null)
+                    throw new NotSupportedException("Actor extra data serialization not implemented");
+
+                using (var ms = new MemoryStream())
+                {
+                    using var bw = new BinaryWriter(ms);
+                    _stringSerializer.Serialize(bw, actor.ParentObjectRoot);
+                    _stringSerializer.Serialize(bw, actor.ParentObjectName);
+                    bw.Write(actor.Components.Count);
+                    foreach (var componentRef in actor.Components)
+                        SerializeObjectReference(bw, componentRef);
+                    bw.Flush();
+                    writer.Write((int)ms.Length);
+                    writer.Write(ms.ToArray());
+                }
+                break;
+            case ComponentObject component:
+                if (component.Properties.Count != 0)
+                    throw new NotSupportedException("Component property serialization not implemented");
+                if (component.ExtraData != null)
+                    throw new NotSupportedException("Component extra data serialization not implemented");
+
+                using (var ms = new MemoryStream())
+                {
+                    using var bw = new BinaryWriter(ms);
+                    _stringSerializer.Serialize(bw, "None");
+                    bw.Flush();
+                    writer.Write((int)ms.Length);
+                    writer.Write(ms.ToArray());
+                }
+                break;
+            default:
+                throw new NotSupportedException($"Object serialization not implemented for type {obj.GetType().Name}");
+        }
+    }
+
+    private void SerializeObjectReference(BinaryWriter writer, ObjectReference reference)
+    {
+        _stringSerializer.Serialize(writer, reference.LevelName);
+        _stringSerializer.Serialize(writer, reference.PathName);
     }
 }


### PR DESCRIPTION
## Summary
- serialize pre-V8 bodies including objects and collectables
- support ComponentObject and ActorObject serialization with error fallback
- add roundtrip tests for non-empty bodies

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a2c504aea483339b5eed5d87c6ae14