### PR TITLE
Add comprehensive save and property tests

### DIFF
--- a/SatisfactorySaveNet.Tests/BodySerializerTests.cs
+++ b/SatisfactorySaveNet.Tests/BodySerializerTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using SatisfactorySaveNet;
+using SatisfactorySaveNet.Abstracts.Model;
+using SatisfactorySaveNet.Abstracts.Model.Properties;
+
+namespace SatisfactorySaveNet.Tests;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class BodySerializerTests
+{
+    [Test]
+    public void Deserialize_NonEmpty_Body()
+    {
+        var header = new Header
+        {
+            HeaderVersion = 5,
+            SaveVersion = 10,
+            BuildVersion = 1,
+            MapName = "Map",
+            MapOptions = string.Empty,
+            SessionName = "Session",
+            PlayedSeconds = 0,
+            SaveDateTimeUtc = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            SessionVisibility = 0
+        };
+
+        using var bodyStream = new MemoryStream();
+        using (var writer = new BinaryWriter(bodyStream, System.Text.Encoding.UTF8, true))
+        {
+            // One object header
+            writer.Write(1);
+            writer.Write(ComponentObject.TypeID);
+            StringSerializer.Instance.Serialize(writer, "/Game/Type");
+            StringSerializer.Instance.Serialize(writer, "Level");
+            StringSerializer.Instance.Serialize(writer, "Path");
+            StringSerializer.Instance.Serialize(writer, "Parent");
+
+            // One object
+            writer.Write(1);
+
+            using var objectData = new MemoryStream();
+            using (var objWriter = new BinaryWriter(objectData, System.Text.Encoding.UTF8, true))
+            {
+                using var props = new MemoryStream();
+                using (var propWriter = new BinaryWriter(props, System.Text.Encoding.UTF8, true))
+                {
+                    StringSerializer.Instance.Serialize(propWriter, "MyInt");
+                    StringSerializer.Instance.Serialize(propWriter, nameof(IntProperty));
+                    propWriter.Write(4); // binarySize (ignored)
+                    propWriter.Write(0); // index
+                    propWriter.Write((sbyte)0);
+                    propWriter.Write(123);
+                    StringSerializer.Instance.Serialize(propWriter, "None");
+                }
+                var propBytes = props.ToArray();
+                objWriter.Write(propBytes.Length + 4); // binary size includes extra data
+                objWriter.Write(propBytes);
+                objWriter.Write(new byte[4]); // extra data placeholder
+            }
+            var objectBytes = objectData.ToArray();
+            writer.Write(objectBytes);
+
+            // No collectables
+            writer.Write(0);
+        }
+
+        bodyStream.Position = 0;
+        using var reader = new BinaryReader(bodyStream);
+        var body = BodySerializer.Instance.Deserialize(reader, header) as BodyPreV8;
+
+        body.Should().NotBeNull();
+        body!.Objects.Should().HaveCount(1);
+        var obj = body.Objects.First();
+        obj.Properties.Should().HaveCount(1);
+        obj.Properties.First().Should().BeOfType<IntProperty>().Which.Value.Should().Be(123);
+    }
+}

--- a/SatisfactorySaveNet.Tests/PropertySerializerTests.cs
+++ b/SatisfactorySaveNet.Tests/PropertySerializerTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using SatisfactorySaveNet;
+using SatisfactorySaveNet.Abstracts.Model.Properties;
+
+namespace SatisfactorySaveNet.Tests;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class PropertySerializerTests
+{
+    private static void WriteString(BinaryWriter writer, string value) => StringSerializer.Instance.Serialize(writer, value);
+
+    [Test]
+    public void Deserialize_IntProperty()
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true))
+        {
+            WriteString(writer, "MyInt");
+            WriteString(writer, nameof(IntProperty));
+            writer.Write(4);
+            writer.Write(0);
+            writer.Write((sbyte)0);
+            writer.Write(42);
+        }
+        stream.Position = 0;
+        using var reader = new BinaryReader(stream);
+        var property = PropertySerializer.Instance.DeserializeProperty(reader);
+        property.Should().BeOfType<IntProperty>().Which.Value.Should().Be(42);
+    }
+
+    [Test]
+    public void Deserialize_FloatProperty()
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true))
+        {
+            WriteString(writer, "MyFloat");
+            WriteString(writer, nameof(FloatProperty));
+            writer.Write(4);
+            writer.Write(0);
+            writer.Write((sbyte)0);
+            writer.Write(3.14f);
+        }
+        stream.Position = 0;
+        using var reader = new BinaryReader(stream);
+        var property = PropertySerializer.Instance.DeserializeProperty(reader);
+        property.Should().BeOfType<FloatProperty>().Which.Value.Should().Be(3.14f);
+    }
+
+    [Test]
+    public void Deserialize_BoolProperty()
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true))
+        {
+            WriteString(writer, "MyBool");
+            WriteString(writer, nameof(BoolProperty));
+            writer.Write(0);
+            writer.Write(0);
+            writer.Write((sbyte)1);
+            writer.Write((sbyte)0);
+        }
+        stream.Position = 0;
+        using var reader = new BinaryReader(stream);
+        var property = PropertySerializer.Instance.DeserializeProperty(reader);
+        property.Should().BeOfType<BoolProperty>().Which.Value.Should().Be(1);
+    }
+
+    [Test]
+    public void Deserialize_StrProperty()
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true))
+        {
+            WriteString(writer, "MyStr");
+            WriteString(writer, nameof(StrProperty));
+            writer.Write(4);
+            writer.Write(0);
+            writer.Write((sbyte)0);
+            WriteString(writer, "Hello");
+        }
+        stream.Position = 0;
+        using var reader = new BinaryReader(stream);
+        var property = PropertySerializer.Instance.DeserializeProperty(reader);
+        property.Should().BeOfType<StrProperty>().Which.Value.Should().Be("Hello");
+    }
+
+    [Test]
+    public void Deserialize_UnknownProperty_Throws()
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true))
+        {
+            WriteString(writer, "Prop");
+            WriteString(writer, "UnknownProperty");
+        }
+        stream.Position = 0;
+        using var reader = new BinaryReader(stream);
+        var act = () => PropertySerializer.Instance.DeserializeProperty(reader);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/SatisfactorySaveNet.Tests/SaveFileSerializerCompressedTests.cs
+++ b/SatisfactorySaveNet.Tests/SaveFileSerializerCompressedTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using FluentAssertions;
+using SatisfactorySaveNet;
+using SatisfactorySaveNet.Abstracts.Exceptions;
+using SatisfactorySaveNet.Abstracts.Model;
+
+namespace SatisfactorySaveNet.Tests;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class SaveFileSerializerCompressedTests
+{
+    private static byte[] CreateCompressedSave(bool corrupt = false)
+    {
+        var header = new Header
+        {
+            HeaderVersion = 5,
+            SaveVersion = 21,
+            BuildVersion = 1,
+            MapName = "Map",
+            MapOptions = string.Empty,
+            SessionName = "Session",
+            PlayedSeconds = 0,
+            SaveDateTimeUtc = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            SessionVisibility = 0
+        };
+
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true);
+
+        HeaderSerializer.Instance.Serialize(writer, header);
+
+        using var body = new MemoryStream();
+        using (var bw = new BinaryWriter(body, System.Text.Encoding.UTF8, true))
+        {
+            bw.Write(0); // nrObjectHeaders
+            bw.Write(0); // nrObjects
+            bw.Write(0); // nrCollectables
+        }
+        var bodyBytes = body.ToArray();
+
+        using var uncompressed = new MemoryStream();
+        using (var bw = new BinaryWriter(uncompressed, System.Text.Encoding.UTF8, true))
+        {
+            bw.Write(bodyBytes.Length);
+            bw.Write(bodyBytes);
+        }
+        var uncompressedBytes = uncompressed.ToArray();
+
+        using var compressed = new MemoryStream();
+        using (var z = new ZLibStream(compressed, CompressionLevel.Optimal, true))
+        {
+            z.Write(uncompressedBytes, 0, uncompressedBytes.Length);
+        }
+        var compressedBytes = compressed.ToArray();
+
+        // Chunk header
+        writer.Write(ChunkInfo.MagicValue);
+        writer.Write(0);
+        writer.Write(ChunkInfo.ChunkSize);
+        writer.Write(0);
+
+        // Summary chunk
+        writer.Write(compressedBytes.Length);
+        writer.Write(0);
+        writer.Write(uncompressedBytes.Length);
+        writer.Write(0);
+
+        // Sub chunk (allow corruption)
+        writer.Write(compressedBytes.Length);
+        writer.Write(0);
+        writer.Write(corrupt ? uncompressedBytes.Length + 1 : uncompressedBytes.Length);
+        writer.Write(0);
+
+        writer.Write(compressedBytes);
+
+        return stream.ToArray();
+    }
+
+    [Test]
+    public void Deserialize_Compressed_Save()
+    {
+        var data = CreateCompressedSave();
+        var save = SaveFileSerializer.Instance.Deserialize(data);
+        save.Header.SaveVersion.Should().Be(21);
+        save.Body.Should().BeOfType<BodyPreV8>();
+    }
+
+    [Test]
+    public void Deserialize_Corrupted_Chunk_Throws()
+    {
+        var data = CreateCompressedSave(corrupt: true);
+        var act = () => SaveFileSerializer.Instance.Deserialize(data);
+        act.Should().Throw<CorruptedSatisFactorySaveFileException>();
+    }
+}


### PR DESCRIPTION
## Summary
- Verify decompression and chunk validation for compressed saves
- Add body deserialization test with object and property
- Cover diverse property types and unknown property regression

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a2c51ee864833398f1c0defd86e63b