### PR TITLE
Add array handlers for additional property types

### DIFF
--- a/SatisfactorySaveNet.Abstracts/Model/Properties/ArrayFINNetworkProperty.cs
+++ b/SatisfactorySaveNet.Abstracts/Model/Properties/ArrayFINNetworkProperty.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+namespace SatisfactorySaveNet.Abstracts.Model.Properties;
+
+public class ArrayFINNetworkProperty : ArrayPropertyBase
+{
+    public override ArrayPropertyConstraint ArrayValueType => ArrayPropertyConstraint.FINNetwork;
+
+    public ICollection<FINNetworkProperty> Values { get; set; } = [];
+}
+

--- a/SatisfactorySaveNet.Abstracts/Model/Properties/ArrayInt8Property.cs
+++ b/SatisfactorySaveNet.Abstracts/Model/Properties/ArrayInt8Property.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+namespace SatisfactorySaveNet.Abstracts.Model.Properties;
+
+public class ArrayInt8Property : ArrayPropertyBase
+{
+    public override ArrayPropertyConstraint ArrayValueType => ArrayPropertyConstraint.Int8;
+
+    public ICollection<sbyte> Values { get; set; } = [];
+}
+

--- a/SatisfactorySaveNet.Abstracts/Model/Properties/ArrayNameProperty.cs
+++ b/SatisfactorySaveNet.Abstracts/Model/Properties/ArrayNameProperty.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+namespace SatisfactorySaveNet.Abstracts.Model.Properties;
+
+public class ArrayNameProperty : ArrayPropertyBase
+{
+    public override ArrayPropertyConstraint ArrayValueType => ArrayPropertyConstraint.Name;
+
+    public ICollection<string> Values { get; set; } = [];
+}
+

--- a/SatisfactorySaveNet.Abstracts/Model/Properties/ArrayUInt32Property.cs
+++ b/SatisfactorySaveNet.Abstracts/Model/Properties/ArrayUInt32Property.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+namespace SatisfactorySaveNet.Abstracts.Model.Properties;
+
+public class ArrayUInt32Property : ArrayPropertyBase
+{
+    public override ArrayPropertyConstraint ArrayValueType => ArrayPropertyConstraint.UInt32;
+
+    public ICollection<uint> Values { get; set; } = [];
+}
+

--- a/SatisfactorySaveNet.Abstracts/Model/Properties/PropertyConstraint.cs
+++ b/SatisfactorySaveNet.Abstracts/Model/Properties/PropertyConstraint.cs
@@ -15,5 +15,9 @@ public enum ArrayPropertyConstraint
     String,
     Struct,
     Text,
-    UInt64
+    UInt64,
+    Name,
+    UInt32,
+    Int8,
+    FINNetwork
 }

--- a/SatisfactorySaveNet.Tests/PropertySerializerArrayTests.cs
+++ b/SatisfactorySaveNet.Tests/PropertySerializerArrayTests.cs
@@ -1,0 +1,102 @@
+using FluentAssertions;
+using NUnit.Framework;
+using SatisfactorySaveNet.Abstracts;
+using SatisfactorySaveNet.Abstracts.Model;
+using SatisfactorySaveNet.Abstracts.Model.Properties;
+using System.IO;
+using System.Linq;
+
+namespace SatisfactorySaveNet.Tests;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class PropertySerializerArrayTests
+{
+    private readonly IPropertySerializer _serializer = PropertySerializer.Instance;
+    private readonly Header _header = new();
+
+    [Test]
+    public void Deserialize_ArrayNameProperty()
+    {
+        using var ms = new MemoryStream();
+        using var writer = new BinaryWriter(ms);
+        writer.Write(0); // binarySize
+        writer.Write(0); // index
+        StringSerializer.Instance.Serialize(writer, nameof(NameProperty));
+        writer.Write((sbyte)0); // padding
+        writer.Write(2); // count
+        StringSerializer.Instance.Serialize(writer, "First");
+        StringSerializer.Instance.Serialize(writer, "Second");
+        ms.Position = 0;
+
+        var property = (ArrayProperty)_serializer.DeserializeProperty(new BinaryReader(ms), _header, nameof(ArrayProperty))!;
+        property.Property.Should().BeOfType<ArrayNameProperty>()
+            .Which.Values.Should().Equal(new[] { "First", "Second" });
+    }
+
+    [Test]
+    public void Deserialize_ArrayUInt32Property()
+    {
+        using var ms = new MemoryStream();
+        using var writer = new BinaryWriter(ms);
+        writer.Write(0);
+        writer.Write(0);
+        StringSerializer.Instance.Serialize(writer, nameof(UInt32Property));
+        writer.Write((sbyte)0);
+        writer.Write(2);
+        writer.Write((uint)1);
+        writer.Write((uint)2);
+        ms.Position = 0;
+
+        var property = (ArrayProperty)_serializer.DeserializeProperty(new BinaryReader(ms), _header, nameof(ArrayProperty))!;
+        property.Property.Should().BeOfType<ArrayUInt32Property>()
+            .Which.Values.Should().Equal(new uint[] { 1u, 2u });
+    }
+
+    [Test]
+    public void Deserialize_ArrayInt8Property()
+    {
+        using var ms = new MemoryStream();
+        using var writer = new BinaryWriter(ms);
+        writer.Write(0);
+        writer.Write(0);
+        StringSerializer.Instance.Serialize(writer, nameof(Int8Property));
+        writer.Write((sbyte)0);
+        writer.Write(2);
+        writer.Write((sbyte)1);
+        writer.Write((sbyte)-2);
+        ms.Position = 0;
+
+        var property = (ArrayProperty)_serializer.DeserializeProperty(new BinaryReader(ms), _header, nameof(ArrayProperty))!;
+        property.Property.Should().BeOfType<ArrayInt8Property>()
+            .Which.Values.Should().Equal(new sbyte[] { 1, -2 });
+    }
+
+    [Test]
+    public void Deserialize_ArrayFINNetworkProperty()
+    {
+        using var ms = new MemoryStream();
+        using var writer = new BinaryWriter(ms);
+        writer.Write(0);
+        writer.Write(0);
+        StringSerializer.Instance.Serialize(writer, nameof(FINNetworkProperty));
+        writer.Write((sbyte)0);
+        writer.Write(1); // count
+        // element
+        StringSerializer.Instance.Serialize(writer, "Level");
+        StringSerializer.Instance.Serialize(writer, "Path");
+        writer.Write(0); // previous flag
+        writer.Write(0); // step flag
+        ms.Position = 0;
+
+        var property = (ArrayProperty)_serializer.DeserializeProperty(new BinaryReader(ms), _header, nameof(ArrayProperty))!;
+        var array = property.Property.Should().BeOfType<ArrayFINNetworkProperty>().Subject;
+        array.Values.Should().ContainSingle();
+        var element = array.Values.Single();
+        element.ObjectReference.LevelName.Should().Be("Level");
+        element.ObjectReference.PathName.Should().Be("Path");
+        element.Previous.Should().BeNull();
+        element.Step.Should().BeNull();
+    }
+}
+

--- a/SatisfactorySaveNet/PropertySerializer.cs
+++ b/SatisfactorySaveNet/PropertySerializer.cs
@@ -107,6 +107,30 @@ public class PropertySerializer : IPropertySerializer
         return property;
     }
 
+    /// <summary>
+    /// Deserializes array property values.
+    /// Supported types:
+    /// <list type="bullet">
+    /// <item><description>ByteProperty</description></item>
+    /// <item><description>BoolProperty</description></item>
+    /// <item><description>IntProperty</description></item>
+    /// <item><description>Int64Property</description></item>
+    /// <item><description>UInt64Property</description></item>
+    /// <item><description>DoubleProperty</description></item>
+    /// <item><description>FloatProperty</description></item>
+    /// <item><description>EnumProperty</description></item>
+    /// <item><description>StrProperty</description></item>
+    /// <item><description>TextProperty</description></item>
+    /// <item><description>SoftObjectProperty</description></item>
+    /// <item><description>ObjectProperty</description></item>
+    /// <item><description>InterfaceProperty</description></item>
+    /// <item><description>StructProperty</description></item>
+    /// <item><description>NameProperty</description></item>
+    /// <item><description>UInt32Property</description></item>
+    /// <item><description>Int8Property</description></item>
+    /// <item><description>FINNetworkProperty</description></item>
+    /// </list>
+    /// </summary>
     private ArrayPropertyBase DeserializeArrayProperty(BinaryReader reader, Header header, string type, int count)
     {
         return type switch
@@ -125,7 +149,10 @@ public class PropertySerializer : IPropertySerializer
             nameof(ObjectProperty) => DeserializeArrayObjectProperty(reader, count),
             nameof(InterfaceProperty) => DeserializeArrayInterfaceProperty(reader, count),
             nameof(StructProperty) => DeserializeArrayStructProperty(reader, header, count),
-            //ToDo: All implemented?
+            nameof(NameProperty) => DeserializeArrayNameProperty(reader, count),
+            nameof(UInt32Property) => DeserializeArrayUInt32Property(reader, count),
+            nameof(Int8Property) => DeserializeArrayInt8Property(reader, count),
+            nameof(FINNetworkProperty) => DeserializeArrayFINNetworkProperty(reader, count),
 
             _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
         };
@@ -337,6 +364,66 @@ public class PropertySerializer : IPropertySerializer
         }
 
         return new ArraySoftObjectProperty
+        {
+            Values = values
+        };
+    }
+
+    private ArrayNameProperty DeserializeArrayNameProperty(BinaryReader reader, int count)
+    {
+        var values = new string[count];
+
+        for (var x = 0; x < count; x++)
+        {
+            values[x] = _stringSerializer.Deserialize(reader);
+        }
+
+        return new ArrayNameProperty
+        {
+            Values = values
+        };
+    }
+
+    private static ArrayUInt32Property DeserializeArrayUInt32Property(BinaryReader reader, int count)
+    {
+        var values = new uint[count];
+
+        for (var x = 0; x < count; x++)
+        {
+            values[x] = reader.ReadUInt32();
+        }
+
+        return new ArrayUInt32Property
+        {
+            Values = values
+        };
+    }
+
+    private static ArrayInt8Property DeserializeArrayInt8Property(BinaryReader reader, int count)
+    {
+        var values = new sbyte[count];
+
+        for (var x = 0; x < count; x++)
+        {
+            values[x] = reader.ReadSByte();
+        }
+
+        return new ArrayInt8Property
+        {
+            Values = values
+        };
+    }
+
+    private ArrayFINNetworkProperty DeserializeArrayFINNetworkProperty(BinaryReader reader, int count)
+    {
+        var values = new FINNetworkProperty[count];
+
+        for (var x = 0; x < count; x++)
+        {
+            values[x] = DeserializeFINNetworkProperty(reader);
+        }
+
+        return new ArrayFINNetworkProperty
         {
             Values = values
         };


### PR DESCRIPTION
## Summary
- add array property classes for Name, UInt32, Int8, and FINNetwork
- implement deserialization and documentation for new array types
- test deserialization for added array property types

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a2c52fa83483339922c6ac99f9b344