### PR TITLE
Rename cargo object raw data field and add round-trip tests

### DIFF
--- a/SatisfactorySaveNet.Abstracts/Extra/CargoObject.cs
+++ b/SatisfactorySaveNet.Abstracts/Extra/CargoObject.cs
@@ -3,5 +3,9 @@ namespace SatisfactorySaveNet.Abstracts.Extra;
 public class CargoObject
 {
     public string Name { get; set; } = string.Empty;
-    public string Unknown { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Raw hex-encoded payload associated with the cargo object.
+    /// </summary>
+    public string SerializedData { get; set; } = string.Empty;
 }

--- a/SatisfactorySaveNet.Tests/ExtraDataSerializerTests.cs
+++ b/SatisfactorySaveNet.Tests/ExtraDataSerializerTests.cs
@@ -1,0 +1,59 @@
+using System.IO;
+using System.Linq;
+using System.Text;
+using FluentAssertions;
+using NUnit.Framework;
+using SatisfactorySaveNet;
+using SatisfactorySaveNet.Abstracts.Extra;
+using SatisfactorySaveNet.Abstracts.Model;
+
+namespace SatisfactorySaveNet.Tests;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class ExtraDataSerializerTests
+{
+    private const string VehiclePath = "/Game/FactoryGame/Buildable/Vehicle/Tractor/BP_Tractor.BP_Tractor_C";
+
+    [TestCase(40, 53)]
+    [TestCase(41, 105)]
+    public void VehicleData_round_trips(int saveVersion, int payloadSize)
+    {
+        var header = new Header { SaveVersion = saveVersion, HeaderVersion = 0 };
+        var count = 1;
+        var name = "Cargo";
+        var payload = new string('A', payloadSize);
+
+        using var ms = new MemoryStream();
+        using (var writer = new BinaryWriter(ms, Encoding.UTF8, true))
+        {
+            writer.Write(count);
+            writer.Write(1); // element count
+            StringSerializer.Instance.Serialize(writer, name);
+            HexSerializer.Instance.Serialize(writer, payload);
+        }
+        var bytes = ms.ToArray();
+
+        using var reader = new BinaryReader(new MemoryStream(bytes));
+        var extra = ExtraDataSerializer.Instance.Deserialize(reader, VehiclePath, header, bytes.Length);
+
+        extra.Should().BeOfType<VehicleData>();
+        var vehicle = (VehicleData)extra!;
+        vehicle.Count.Should().Be(count);
+        vehicle.CargoObjects.Should().ContainSingle();
+        var cargo = vehicle.CargoObjects.First();
+        cargo.Name.Should().Be(name);
+        cargo.SerializedData.Should().Be(payload);
+
+        using var roundtrip = new MemoryStream();
+        using (var writer = new BinaryWriter(roundtrip, Encoding.UTF8, true))
+        {
+            writer.Write(vehicle.Count);
+            writer.Write(vehicle.CargoObjects.Count);
+            StringSerializer.Instance.Serialize(writer, cargo.Name);
+            HexSerializer.Instance.Serialize(writer, cargo.SerializedData);
+        }
+
+        roundtrip.ToArray().Should().Equal(bytes);
+    }
+}

--- a/SatisfactorySaveNet/ExtraDataSerializer.cs
+++ b/SatisfactorySaveNet/ExtraDataSerializer.cs
@@ -591,17 +591,17 @@ public class ExtraDataSerializer : IExtraDataSerializer
         var nrElements = reader.ReadInt32();
         var vehicleObjects = new CargoObject[nrElements];
 
-        var unknownSize = header.SaveVersion >= 41 ? 105 : 53;
+        var serializedDataSize = header.SaveVersion >= 41 ? 105 : 53;
 
         for (var x = 0; x < nrElements; x++)
         {
             var name = _stringSerializer.Deserialize(reader);
-            var unknown = _hexSerializer.Deserialize(reader, unknownSize);
+            var serializedData = _hexSerializer.Deserialize(reader, serializedDataSize);
 
             vehicleObjects[x] = new CargoObject
             {
                 Name = name,
-                Unknown = unknown,
+                SerializedData = serializedData,
             };
         }
 
@@ -647,17 +647,17 @@ public class ExtraDataSerializer : IExtraDataSerializer
         var nrElements = reader.ReadInt32();
         var vehicleObjects = new CargoObject[nrElements];
 
-        var unknownSize = header.SaveVersion >= 41 ? 105 : 53;
+        var serializedDataSize = header.SaveVersion >= 41 ? 105 : 53;
 
         for (var x = 0; x < nrElements; x++)
         {
             var name = _stringSerializer.Deserialize(reader);
-            var unknown = _hexSerializer.Deserialize(reader, unknownSize);
+            var serializedData = _hexSerializer.Deserialize(reader, serializedDataSize);
 
             vehicleObjects[x] = new CargoObject
             {
                 Name = name,
-                Unknown = unknown,
+                SerializedData = serializedData,
             };
         }
 


### PR DESCRIPTION
## Summary
- rename `CargoObject.Unknown` to `SerializedData` and wire up deserialization
- cover `VehicleData` extra payload with round-trip tests for pre- and post-41 saves

## Testing
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68a2c530bf30833383506876d89b8733