### PR TITLE
feat: stub modern body serialization

### DIFF
--- a/SatisfactorySaveNet/BodySerializer.cs
+++ b/SatisfactorySaveNet/BodySerializer.cs
@@ -4,6 +4,7 @@ using SatisfactorySaveNet.Abstracts.Model;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace SatisfactorySaveNet;
 
@@ -255,6 +256,9 @@ public class BodySerializer : IBodySerializer
             case BodyPreV8 preV8:
                 SerializePreV8(writer, preV8);
                 break;
+            case BodyV8 v8:
+                SerializeV8(writer, header, v8);
+                break;
             default:
                 throw new NotSupportedException("Body serialization for this version is not implemented");
         }
@@ -274,5 +278,43 @@ public class BodySerializer : IBodySerializer
         writer.Write(body.Collectables.Count);
         if (body.Collectables.Count != 0)
             throw new NotSupportedException("Collectable serialization not implemented");
+    }
+
+    private void SerializeV8(BinaryWriter writer, Header header, BodyV8 body)
+    {
+        if (header.SaveVersion < 41)
+            throw new NotSupportedException("BodyV8 serialization for save versions below 41 is not implemented");
+
+        // Only support a single persistent level with no objects or collectables
+        if (body.Grid is not null)
+            throw new NotSupportedException("Grid serialization not implemented");
+
+        if (body.ObjectReferences is { Count: > 0 })
+            throw new NotSupportedException("Object reference serialization not implemented");
+
+        if (body.Levels.Count != 1)
+            throw new NotSupportedException("BodyV8 serialization only supports an empty persistent level");
+
+        var level = body.Levels.First();
+        if (level.Objects.Count != 0 || level.Collectables.Count != 0 || (level.SecondCollectables?.Count ?? 0) != 0)
+            throw new NotSupportedException("BodyV8 serialization only supports an empty persistent level");
+
+        // no non-persistent levels
+        writer.Write(0);
+
+        // binary length of persistent level block
+        const long binaryLength = 24; // nrObjectHeaders + nrCollectables + binarySizeObjects + nrObjects + nrSecondCollectables
+        writer.Write(binaryLength);
+
+        // nrObjectHeaders
+        writer.Write(0);
+        // nrCollectables
+        writer.Write(0);
+        // binarySizeObjects (only nrObjects int)
+        writer.Write(4L);
+        // nrObjects
+        writer.Write(0);
+        // nrSecondCollectables
+        writer.Write(0);
     }
 }


### PR DESCRIPTION
## Summary
- add BodyV8 serialization stub supporting only an empty persistent level

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a2da4e0bc083339951018b824cd641