### PR TITLE
Add save v51 body serialization

### DIFF
--- a/SatisfactorySaveNet.Tests/BodySerializerTests.cs
+++ b/SatisfactorySaveNet.Tests/BodySerializerTests.cs
@@ -181,7 +181,7 @@ public class BodySerializerTests
     }
 
     [Test]
-    public void SerializeV8_WithObject_RoundTrip_SaveVersion51()
+    public void SerializeV8_WithCollectablesAndReferences_RoundTrip_SaveVersion51()
     {
         var header = new Header
         {
@@ -211,8 +211,14 @@ public class BodySerializerTests
 
         var level = new Level();
         level.Objects.Add(actor);
+        level.Collectables.Add(new ObjectReference { LevelName = "Level", PathName = "/Game/Collectable1" });
+        level.SecondCollectables!.Add(new ObjectReference { LevelName = "Level", PathName = "/Game/Collectable2" });
         var body = new BodyV8();
         body.Levels.Add(level);
+        body.ObjectReferences = new List<ObjectReference>
+        {
+            new ObjectReference { LevelName = "Level", PathName = "/Game/GlobalRef" }
+        };
 
         using var stream = new MemoryStream();
         using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true))
@@ -225,12 +231,20 @@ public class BodySerializerTests
         var roundTripped = BodySerializer.Instance.Deserialize(reader, header) as BodyV8;
 
         roundTripped.Should().NotBeNull();
-        roundTripped!.Levels.Single().Objects.Should().HaveCount(1);
-        var rtActor = roundTripped.Levels.Single().Objects.First() as ActorObject;
+        var rtLevel = roundTripped!.Levels.Single();
+        rtLevel.Objects.Should().HaveCount(1);
+        rtLevel.Collectables.Should().HaveCount(1);
+        rtLevel.SecondCollectables.Should().HaveCount(1);
+        roundTripped.ObjectReferences.Should().HaveCount(1);
+
+        var rtActor = rtLevel.Objects.First() as ActorObject;
         rtActor.Should().NotBeNull();
         rtActor!.TypePath.Should().Be("/Game/Actor");
         rtActor.Position.X.Should().Be(1f);
         rtActor.Position.Y.Should().Be(2f);
         rtActor.Position.Z.Should().Be(3f);
+        rtLevel.Collectables.First().PathName.Should().Be("/Game/Collectable1");
+        rtLevel.SecondCollectables.First().PathName.Should().Be("/Game/Collectable2");
+        roundTripped.ObjectReferences!.First().PathName.Should().Be("/Game/GlobalRef");
     }
 }

--- a/SatisfactorySaveNet.Tests/BodySerializerTests.cs
+++ b/SatisfactorySaveNet.Tests/BodySerializerTests.cs
@@ -179,4 +179,58 @@ public class BodySerializerTests
         rtActor.Position.Y.Should().Be(2f);
         rtActor.Position.Z.Should().Be(3f);
     }
+
+    [Test]
+    public void SerializeV8_WithObject_RoundTrip_SaveVersion51()
+    {
+        var header = new Header
+        {
+            HeaderVersion = 7,
+            SaveVersion = 51,
+            BuildVersion = 1,
+            MapName = "Map",
+            MapOptions = string.Empty,
+            SessionName = "Session",
+            PlayedSeconds = 0,
+            SaveDateTimeUtc = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            SessionVisibility = 0
+        };
+
+        var actor = new ActorObject
+        {
+            TypePath = "/Game/Actor",
+            ObjectReference = new ObjectReference { LevelName = "Level", PathName = "/Game/Actor" },
+            NeedTransform = 1,
+            Rotation = new Vector4(0, 0, 0, 1),
+            Position = new Vector3(1, 2, 3),
+            Scale = new Vector3(1, 1, 1),
+            PlacedInLevel = 1,
+            ParentObjectRoot = string.Empty,
+            ParentObjectName = string.Empty
+        };
+
+        var level = new Level();
+        level.Objects.Add(actor);
+        var body = new BodyV8();
+        body.Levels.Add(level);
+
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true))
+        {
+            BodySerializer.Instance.Serialize(writer, header, body);
+        }
+
+        stream.Position = 0;
+        using var reader = new BinaryReader(stream);
+        var roundTripped = BodySerializer.Instance.Deserialize(reader, header) as BodyV8;
+
+        roundTripped.Should().NotBeNull();
+        roundTripped!.Levels.Single().Objects.Should().HaveCount(1);
+        var rtActor = roundTripped.Levels.Single().Objects.First() as ActorObject;
+        rtActor.Should().NotBeNull();
+        rtActor!.TypePath.Should().Be("/Game/Actor");
+        rtActor.Position.X.Should().Be(1f);
+        rtActor.Position.Y.Should().Be(2f);
+        rtActor.Position.Z.Should().Be(3f);
+    }
 }

--- a/SatisfactorySaveNet/BodySerializer.cs
+++ b/SatisfactorySaveNet/BodySerializer.cs
@@ -290,14 +290,100 @@ public class BodySerializer : IBodySerializer
         if (header.SaveVersion < 41)
             throw new NotSupportedException("BodyV8 serialization for save versions below 41 is not implemented");
 
-        // Only support a single persistent level with no streaming levels
+        if (header.SaveVersion >= 51)
+        {
+            // Save versions 51+ still include the grid section but introduce
+            // additional data for streaming levels.  We currently only support
+            // a single persistent level and omit streaming level support.
+
+            if (body.Grid is not null)
+                throw new NotSupportedException("Grid serialization not implemented");
+
+            if (body.Levels.Count != 1)
+                throw new NotSupportedException("BodyV8 serialization only supports a single persistent level");
+
+            var level = body.Levels.First();
+
+            // minimal grid
+            writer.Write(1); // partition count
+            _stringSerializer.Serialize(writer, string.Empty);
+            writer.Write(0u);
+            writer.Write(0u);
+            writer.Write(0);
+            _stringSerializer.Serialize(writer, string.Empty);
+            writer.Write(0u);
+
+            // no non-persistent levels
+            writer.Write(0);
+
+            using var levelStream = new MemoryStream();
+            using (var levelWriter = new BinaryWriter(levelStream, System.Text.Encoding.UTF8, true))
+            {
+                // nrObjectHeaders
+                levelWriter.Write(level.Objects.Count);
+                foreach (var obj in level.Objects)
+                {
+                    _objectHeaderSerializer.Serialize(levelWriter, obj, header.SaveVersion);
+                }
+
+                // nrCollectables
+                levelWriter.Write(level.Collectables.Count);
+                foreach (var collectable in level.Collectables)
+                {
+                    _objectReferenceSerializer.Serialize(levelWriter, collectable);
+                }
+
+                using var objectStream = new MemoryStream();
+                using (var objectWriter = new BinaryWriter(objectStream, System.Text.Encoding.UTF8, true))
+                {
+                    objectWriter.Write(level.Objects.Count);
+                    foreach (var obj in level.Objects)
+                    {
+                        _objectSerializer.Serialize(objectWriter, header, obj);
+                    }
+                }
+
+                levelWriter.Write((long)objectStream.Length);
+                levelWriter.Write(objectStream.ToArray());
+
+                // SaveVersion 51+ adds an unknown 32-bit field between objects and
+                // second collectables for streaming levels.  Streaming levels are
+                // not supported yet, so nothing is written here.
+
+                var secondCollectables = level.SecondCollectables ?? Enumerable.Empty<ObjectReference>();
+                levelWriter.Write(secondCollectables.Count());
+                foreach (var collectable in secondCollectables)
+                {
+                    _objectReferenceSerializer.Serialize(levelWriter, collectable);
+                }
+            }
+
+            writer.Write(levelStream.Length);
+            writer.Write(levelStream.ToArray());
+
+            if (body.ObjectReferences is { Count: > 0 })
+            {
+                writer.Write(body.ObjectReferences.Count);
+                foreach (var objRef in body.ObjectReferences)
+                {
+                    _objectReferenceSerializer.Serialize(writer, objRef);
+                }
+            }
+
+            return;
+        }
+
+        // Save versions 41-50.  These include a grid section and allow a single
+        // persistent level with optional objects, collectables and references.
+
+        // Only support a single persistent level with no grid data
         if (body.Grid is not null)
             throw new NotSupportedException("Grid serialization not implemented");
 
         if (body.Levels.Count != 1)
             throw new NotSupportedException("BodyV8 serialization only supports a single persistent level");
 
-        var level = body.Levels.First();
+        var level41 = body.Levels.First();
 
         // minimal grid
         writer.Write(1); // partition count
@@ -311,52 +397,46 @@ public class BodySerializer : IBodySerializer
         // no non-persistent levels
         writer.Write(0);
 
-        using var levelStream = new MemoryStream();
-        using (var levelWriter = new BinaryWriter(levelStream, System.Text.Encoding.UTF8, true))
+        using var levelStream41 = new MemoryStream();
+        using (var levelWriter41 = new BinaryWriter(levelStream41, System.Text.Encoding.UTF8, true))
         {
             // nrObjectHeaders
-            levelWriter.Write(level.Objects.Count);
-            foreach (var obj in level.Objects)
+            levelWriter41.Write(level41.Objects.Count);
+            foreach (var obj in level41.Objects)
             {
-                _objectHeaderSerializer.Serialize(levelWriter, obj, header.SaveVersion);
+                _objectHeaderSerializer.Serialize(levelWriter41, obj, header.SaveVersion);
             }
 
             // nrCollectables
-            levelWriter.Write(level.Collectables.Count);
-            foreach (var collectable in level.Collectables)
+            levelWriter41.Write(level41.Collectables.Count);
+            foreach (var collectable in level41.Collectables)
             {
-                _objectReferenceSerializer.Serialize(levelWriter, collectable);
+                _objectReferenceSerializer.Serialize(levelWriter41, collectable);
             }
 
-            using var objectStream = new MemoryStream();
-            using (var objectWriter = new BinaryWriter(objectStream, System.Text.Encoding.UTF8, true))
+            using var objectStream41 = new MemoryStream();
+            using (var objectWriter41 = new BinaryWriter(objectStream41, System.Text.Encoding.UTF8, true))
             {
-                objectWriter.Write(level.Objects.Count);
-                foreach (var obj in level.Objects)
+                objectWriter41.Write(level41.Objects.Count);
+                foreach (var obj in level41.Objects)
                 {
-                    _objectSerializer.Serialize(objectWriter, header, obj);
+                    _objectSerializer.Serialize(objectWriter41, header, obj);
                 }
             }
 
-            levelWriter.Write((long)objectStream.Length);
-            levelWriter.Write(objectStream.ToArray());
+            levelWriter41.Write((long)objectStream41.Length);
+            levelWriter41.Write(objectStream41.ToArray());
 
-            if (header.SaveVersion >= 51)
+            var secondCollectables41 = level41.SecondCollectables ?? Enumerable.Empty<ObjectReference>();
+            levelWriter41.Write(secondCollectables41.Count());
+            foreach (var collectable in secondCollectables41)
             {
-                // SaveVersion 51+ adds an unknown 32-bit field between objects and second collectables
-                levelWriter.Write(0u);
-            }
-
-            var secondCollectables = level.SecondCollectables ?? Enumerable.Empty<ObjectReference>();
-            levelWriter.Write(secondCollectables.Count());
-            foreach (var collectable in secondCollectables)
-            {
-                _objectReferenceSerializer.Serialize(levelWriter, collectable);
+                _objectReferenceSerializer.Serialize(levelWriter41, collectable);
             }
         }
 
-        writer.Write(levelStream.Length);
-        writer.Write(levelStream.ToArray());
+        writer.Write(levelStream41.Length);
+        writer.Write(levelStream41.ToArray());
 
         if (body.ObjectReferences is { Count: > 0 })
         {

--- a/SatisfactorySaveNet/BodySerializer.cs
+++ b/SatisfactorySaveNet/BodySerializer.cs
@@ -259,9 +259,6 @@ public class BodySerializer : IBodySerializer
             case BodyV8 v8:
                 SerializeV8(writer, header, v8);
                 break;
-            case BodyV8 v8:
-                SerializeV8(writer, header, v8);
-                break;
             default:
                 throw new NotSupportedException("Body serialization for this version is not implemented");
         }
@@ -292,10 +289,8 @@ public class BodySerializer : IBodySerializer
     {
         if (header.SaveVersion < 41)
             throw new NotSupportedException("BodyV8 serialization for save versions below 41 is not implemented");
-        if (header.SaveVersion >= 51)
-            throw new NotSupportedException("BodyV8 serialization for save versions >= 51 is not implemented");
 
-        // Only support a single persistent level with no objects
+        // Only support a single persistent level with no streaming levels
         if (body.Grid is not null)
             throw new NotSupportedException("Grid serialization not implemented");
 
@@ -346,6 +341,12 @@ public class BodySerializer : IBodySerializer
             levelWriter.Write((long)objectStream.Length);
             levelWriter.Write(objectStream.ToArray());
 
+            if (header.SaveVersion >= 51)
+            {
+                // SaveVersion 51+ adds an unknown 32-bit field between objects and second collectables
+                levelWriter.Write(0u);
+            }
+
             var secondCollectables = level.SecondCollectables ?? Enumerable.Empty<ObjectReference>();
             levelWriter.Write(secondCollectables.Count());
             foreach (var collectable in secondCollectables)
@@ -365,43 +366,5 @@ public class BodySerializer : IBodySerializer
                 _objectReferenceSerializer.Serialize(writer, objRef);
             }
         }
-    }
-
-    private void SerializeV8(BinaryWriter writer, Header header, BodyV8 body)
-    {
-        if (header.SaveVersion < 41)
-            throw new NotSupportedException("BodyV8 serialization for save versions below 41 is not implemented");
-
-        // Only support a single persistent level with no objects or collectables
-        if (body.Grid is not null)
-            throw new NotSupportedException("Grid serialization not implemented");
-
-        if (body.ObjectReferences is { Count: > 0 })
-            throw new NotSupportedException("Object reference serialization not implemented");
-
-        if (body.Levels.Count != 1)
-            throw new NotSupportedException("BodyV8 serialization only supports an empty persistent level");
-
-        var level = body.Levels.First();
-        if (level.Objects.Count != 0 || level.Collectables.Count != 0 || (level.SecondCollectables?.Count ?? 0) != 0)
-            throw new NotSupportedException("BodyV8 serialization only supports an empty persistent level");
-
-        // no non-persistent levels
-        writer.Write(0);
-
-        // binary length of persistent level block
-        const long binaryLength = 24; // nrObjectHeaders + nrCollectables + binarySizeObjects + nrObjects + nrSecondCollectables
-        writer.Write(binaryLength);
-
-        // nrObjectHeaders
-        writer.Write(0);
-        // nrCollectables
-        writer.Write(0);
-        // binarySizeObjects (only nrObjects int)
-        writer.Write(4L);
-        // nrObjects
-        writer.Write(0);
-        // nrSecondCollectables
-        writer.Write(0);
     }
 }


### PR DESCRIPTION
## Summary
- support BodyV8 serialization for SaveVersion 51+
- add round-trip test for SaveVersion 51

## Testing
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68a2e8af71fc8333bb12fe02cb30a7a0