### PR TITLE
Use ObjectReference in RailroadTrackPosition

### DIFF
--- a/SatisfactorySaveNet.Abstracts/Model/Typed/RailroadTrackPosition.cs
+++ b/SatisfactorySaveNet.Abstracts/Model/Typed/RailroadTrackPosition.cs
@@ -1,11 +1,12 @@
+using SatisfactorySaveNet.Abstracts.Model;
+
 namespace SatisfactorySaveNet.Abstracts.Model.Typed;
 
 public class RailroadTrackPosition : TypedData
 {
     public override TypedDataConstraint Type => TypedDataConstraint.RailroadTrackPosition;
 
-    public string LevelName { get; set; } = string.Empty; //ToDo: ObjectReference
-    public string PathName { get; set; } = string.Empty;
+    public ObjectReference Track { get; set; } = new();
     public float Offset { get; set; }
     public float Forward { get; set; }
 }

--- a/SatisfactorySaveNet/TypedDataSerializer.cs
+++ b/SatisfactorySaveNet/TypedDataSerializer.cs
@@ -525,15 +525,13 @@ public class TypedDataSerializer : ITypedDataSerializer
 
     private RailroadTrackPosition DeserializeRailroadTrackPosition(BinaryReader reader)
     {
-        var levelName = _stringSerializer.Deserialize(reader); //ToDo: ObjectReference
-        var pathName = _stringSerializer.Deserialize(reader);
+        var track = _objectReferenceSerializer.Deserialize(reader);
         var offset = reader.ReadSingle();
         var forward = reader.ReadSingle();
 
         return new RailroadTrackPosition
         {
-            LevelName = levelName,
-            PathName = pathName,
+            Track = track,
             Offset = offset,
             Forward = forward
         };


### PR DESCRIPTION
## Summary
- replace level/path strings with ObjectReference in RailroadTrackPosition
- deserialize RailroadTrackPosition using ObjectReferenceSerializer

## Testing
- `dotnet test` *(fails: BodySerializer.SerializeV8 duplicate member)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e8af8c808333aaa6898d7a88317c