### PR TITLE
Add SaveVersion 51 tests and tidy serializer

### DIFF
--- a/SatisfactorySaveNet.Tests/SaveVersion51Tests.cs
+++ b/SatisfactorySaveNet.Tests/SaveVersion51Tests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using NUnit.Framework;
+using SatisfactorySaveNet;
+using SatisfactorySaveNet.Abstracts.Model;
+
+namespace SatisfactorySaveNet.Tests;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class SaveVersion51Tests
+{
+    [Test]
+    public void HeaderSerializer_V14_Roundtrip_IncludesNewFields()
+    {
+        var header = new Header
+        {
+            HeaderVersion = 14,
+            SaveVersion = 51,
+            BuildVersion = 1,
+            SaveName = "TestSave",
+            MapName = "Map",
+            MapOptions = "options",
+            SessionName = "Session",
+            PlayedSeconds = 123,
+            SaveDateTimeUtc = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            SessionVisibility = 0,
+            EditorObjectVersion = 1,
+            ModMetadata = "{}",
+            IsModdedSave = 1,
+            SaveIdentifier = "GUID",
+            IsPartitionedWorld = 1,
+            SaveDataHash = "00000000000000000000",
+            IsCreativeModeEnabled = 0
+        };
+
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true))
+        {
+            HeaderSerializer.Instance.Serialize(writer, header);
+        }
+
+        stream.Position = 0;
+        using var reader = new BinaryReader(stream);
+        var roundTripped = HeaderSerializer.Instance.Deserialize(reader);
+
+        roundTripped.Should().BeEquivalentTo(header);
+    }
+
+    [Test]
+    public void BodyDeserializer_V51_WithNonPersistentLevel()
+    {
+        var header = new Header { SaveVersion = 51, MapName = "Map" };
+
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true))
+        {
+            // Minimal grid
+            writer.Write(1); // partition count
+            StringSerializer.Instance.Serialize(writer, string.Empty);
+            writer.Write(0u);
+            writer.Write(0u);
+            writer.Write(0);
+            StringSerializer.Instance.Serialize(writer, string.Empty);
+            writer.Write(0u);
+
+            // One non-persistent level
+            writer.Write(1); // nrLevels
+
+            StringSerializer.Instance.Serialize(writer, "L1"); // level name
+            writer.Write(28L); // binary length
+            writer.Write(0); // nrObjectHeaders
+            writer.Write(0); // nrCollectables
+            writer.Write(4L); // binarySizeObjects
+            writer.Write(0); // nrObjects
+            writer.Write(0u); // unknown
+            writer.Write(0); // nrSecondCollectables
+            writer.Write(0L); // skip
+            writer.Write(51); // saveVersion for level
+
+            // Persistent level (implicit name)
+            writer.Write(24L); // binary length
+            writer.Write(0); // nrObjectHeaders
+            writer.Write(0); // nrCollectables
+            writer.Write(4L); // binarySizeObjects
+            writer.Write(0); // nrObjects
+            writer.Write(0); // nrSecondCollectables
+        }
+
+        stream.Position = 0;
+        using var reader = new BinaryReader(stream);
+        var body = BodySerializer.Instance.Deserialize(reader, header) as BodyV8;
+
+        body.Should().NotBeNull();
+        body!.Levels.Should().HaveCount(2);
+    }
+
+    [Test]
+    public void SaveSerializer_V51_Roundtrip_NotSupported()
+    {
+        var save = new SatisfactorySave
+        {
+            Header = new Header
+            {
+                HeaderVersion = 14,
+                SaveVersion = 51,
+                BuildVersion = 1,
+                SaveName = "TestSave",
+                MapName = "Map",
+                MapOptions = string.Empty,
+                SessionName = "Session",
+                PlayedSeconds = 0,
+                SaveDateTimeUtc = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                SessionVisibility = 0,
+                EditorObjectVersion = 1,
+                ModMetadata = string.Empty,
+                IsModdedSave = 0,
+                SaveIdentifier = "GUID",
+                IsPartitionedWorld = 0,
+                SaveDataHash = "00000000000000000000",
+                IsCreativeModeEnabled = 0
+            },
+            Body = new BodyV8()
+        };
+
+        var data = SaveFileSerializer.Instance.Serialize(save);
+        var result = SaveFileSerializer.Instance.Deserialize(data);
+
+        result.Header.SaveVersion.Should().Be(save.Header.SaveVersion);
+    }
+}
+

--- a/SatisfactorySaveNet/BodySerializer.cs
+++ b/SatisfactorySaveNet/BodySerializer.cs
@@ -259,9 +259,6 @@ public class BodySerializer : IBodySerializer
             case BodyV8 v8:
                 SerializeV8(writer, header, v8);
                 break;
-            case BodyV8 v8:
-                SerializeV8(writer, header, v8);
-                break;
             default:
                 throw new NotSupportedException("Body serialization for this version is not implemented");
         }
@@ -367,41 +364,4 @@ public class BodySerializer : IBodySerializer
         }
     }
 
-    private void SerializeV8(BinaryWriter writer, Header header, BodyV8 body)
-    {
-        if (header.SaveVersion < 41)
-            throw new NotSupportedException("BodyV8 serialization for save versions below 41 is not implemented");
-
-        // Only support a single persistent level with no objects or collectables
-        if (body.Grid is not null)
-            throw new NotSupportedException("Grid serialization not implemented");
-
-        if (body.ObjectReferences is { Count: > 0 })
-            throw new NotSupportedException("Object reference serialization not implemented");
-
-        if (body.Levels.Count != 1)
-            throw new NotSupportedException("BodyV8 serialization only supports an empty persistent level");
-
-        var level = body.Levels.First();
-        if (level.Objects.Count != 0 || level.Collectables.Count != 0 || (level.SecondCollectables?.Count ?? 0) != 0)
-            throw new NotSupportedException("BodyV8 serialization only supports an empty persistent level");
-
-        // no non-persistent levels
-        writer.Write(0);
-
-        // binary length of persistent level block
-        const long binaryLength = 24; // nrObjectHeaders + nrCollectables + binarySizeObjects + nrObjects + nrSecondCollectables
-        writer.Write(binaryLength);
-
-        // nrObjectHeaders
-        writer.Write(0);
-        // nrCollectables
-        writer.Write(0);
-        // binarySizeObjects (only nrObjects int)
-        writer.Write(4L);
-        // nrObjects
-        writer.Write(0);
-        // nrSecondCollectables
-        writer.Write(0);
-    }
 }


### PR DESCRIPTION
## Summary
- add SaveVersion 51 tests covering header round-trip and highlighting unsupported body/save serialization
- remove duplicate `SerializeV8` definition in `BodySerializer`

## Testing
- `dotnet test` *(fails: BodyDeserializer_V51_WithNonPersistentLevel, SaveSerializer_V51_Roundtrip_NotSupported)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e8c0de088333b58e3294835f23ea