### PR TITLE
Validate save file versions in header serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ You can integrate it using [nuget.org](https://www.nuget.org/packages/Satisfacto
 
 Further, (external and promising looking) documentation of the save game format is available [here](https://github.com/moritz-h/satisfactory-3d-map/blob/master/docs/SATISFACTORY_SAVE.md). **Link fixed now sorry**
 
+## Version compatibility
+The library supports save headers up to `SaveHeaderVersion.LatestVersion` and save versions from `FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents` through `FSaveCustomVersion.LatestVersion`. Newer or older saves outside of this range will result in a `NotSupportedException` during deserialization.
+
 ## How to use
 ```CSharp
 ISaveFileSerializer serializer = SaveFileSerializer.Instance;

--- a/SatisfactorySaveNet.Tests/HeaderSerializerTests.cs
+++ b/SatisfactorySaveNet.Tests/HeaderSerializerTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using FluentAssertions;
+
+namespace SatisfactorySaveNet.Tests;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class HeaderSerializerTests
+{
+    [Test]
+    public void Deserialize_Throws_ForTooNewHeaderVersion()
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true))
+        {
+            writer.Write((int)SaveHeaderVersion.LatestVersion + 1);
+            writer.Write((int)FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents);
+            writer.Write(0);
+        }
+
+        stream.Position = 0;
+        using var reader = new BinaryReader(stream);
+
+        Action act = () => HeaderSerializer.Instance.Deserialize(reader);
+        act.Should().Throw<NotSupportedException>().WithMessage("*header version*");
+    }
+
+    [Test]
+    public void Deserialize_Throws_ForUnsupportedSaveVersion()
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true))
+        {
+            writer.Write((int)SaveHeaderVersion.LatestVersion);
+            writer.Write((int)FSaveCustomVersion.LatestVersion + 1);
+            writer.Write(0);
+        }
+
+        stream.Position = 0;
+        using var reader = new BinaryReader(stream);
+
+        Action act = () => HeaderSerializer.Instance.Deserialize(reader);
+        act.Should().Throw<NotSupportedException>().WithMessage("*save version*");
+    }
+}

--- a/SatisfactorySaveNet.Tests/SaveSerializerTests.cs
+++ b/SatisfactorySaveNet.Tests/SaveSerializerTests.cs
@@ -19,7 +19,7 @@ public class SaveSerializerTests
             Header = new Header
             {
                 HeaderVersion = 5,
-                SaveVersion = 10,
+                SaveVersion = (int)FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents,
                 BuildVersion = 1,
                 SaveName = "Test",
                 MapName = "Map",

--- a/SatisfactorySaveNet/BodySerializer.cs
+++ b/SatisfactorySaveNet/BodySerializer.cs
@@ -259,9 +259,6 @@ public class BodySerializer : IBodySerializer
             case BodyV8 v8:
                 SerializeV8(writer, header, v8);
                 break;
-            case BodyV8 v8:
-                SerializeV8(writer, header, v8);
-                break;
             default:
                 throw new NotSupportedException("Body serialization for this version is not implemented");
         }
@@ -367,41 +364,4 @@ public class BodySerializer : IBodySerializer
         }
     }
 
-    private void SerializeV8(BinaryWriter writer, Header header, BodyV8 body)
-    {
-        if (header.SaveVersion < 41)
-            throw new NotSupportedException("BodyV8 serialization for save versions below 41 is not implemented");
-
-        // Only support a single persistent level with no objects or collectables
-        if (body.Grid is not null)
-            throw new NotSupportedException("Grid serialization not implemented");
-
-        if (body.ObjectReferences is { Count: > 0 })
-            throw new NotSupportedException("Object reference serialization not implemented");
-
-        if (body.Levels.Count != 1)
-            throw new NotSupportedException("BodyV8 serialization only supports an empty persistent level");
-
-        var level = body.Levels.First();
-        if (level.Objects.Count != 0 || level.Collectables.Count != 0 || (level.SecondCollectables?.Count ?? 0) != 0)
-            throw new NotSupportedException("BodyV8 serialization only supports an empty persistent level");
-
-        // no non-persistent levels
-        writer.Write(0);
-
-        // binary length of persistent level block
-        const long binaryLength = 24; // nrObjectHeaders + nrCollectables + binarySizeObjects + nrObjects + nrSecondCollectables
-        writer.Write(binaryLength);
-
-        // nrObjectHeaders
-        writer.Write(0);
-        // nrCollectables
-        writer.Write(0);
-        // binarySizeObjects (only nrObjects int)
-        writer.Write(4L);
-        // nrObjects
-        writer.Write(0);
-        // nrSecondCollectables
-        writer.Write(0);
-    }
 }

--- a/SatisfactorySaveNet/FSaveCustomVersion.cs
+++ b/SatisfactorySaveNet/FSaveCustomVersion.cs
@@ -1,0 +1,96 @@
+namespace SatisfactorySaveNet;
+
+public enum FSaveCustomVersion
+{
+    /** 2016/12/20 - Initial version of the save system, saves some character stuff like inventory and health */
+    BeforeCustomVersionWasAdded = 0,
+
+    /** 2017/01/23 - Now storing transform for all saved actors */
+    DROPPED_StoreTransform,
+
+    /** 2017/01/25 - Change object header, stops storing map name in savefile. Breaks all backward compability */
+    DROPPED_ChangeObjectHeader,
+
+    /** 2017/01/30 - Changed serialization of property names to strings instead of ints. Breaks all backward compability  */
+    DROPPED_PropertyTagsAsStrings,
+
+    /** 2017/01/31 - Now store the body state of all vehicles */
+    DROPPED_StoreVehiclesBodyState,
+
+    /** 2017/02/13 - Store if a actor was stored in the level in the actor TOC */
+    DROPPED_ActorPlacedInLevelSaved,
+
+    /** 2017/05/02 - Removed outer from save in actor header, now it's saved as a part of the actors property set */
+    DROPPED_MovedActorOuter,
+
+    /** 2017/05/23 - Rewrote power connections to use actor components. */
+    DROPPED_PowerConnectionComponents,
+
+    // 2017-10-09: Serialize train timetable
+    DROPPED_SerializeTrainTimetable,
+
+    // 2017-10-27: FactoryConnection transform converted from World to local
+    DROPPED_FactoryConnectionWorldToLocal,
+
+    // 2017-11-03: Circuits are now objects and not structs.
+    DROPPED_CircuitObjects,
+
+    // 2018-02-12: DockingStations now only have one inventory
+    DROPPED_DockingStationSingleInventory,
+
+    // 2018-03-06: Saving build shortcuts
+    DROPPED_SavingBuildShortcuts,
+
+    // 2018-04-05 Game Phase manager has been added and functionality has been moved from GameState.
+    DROPPED_GamePhaseManagerAdded,
+
+    // 2018-10-25 No longer save relative transforms for UFGConnectionComponent.
+    DROPPED_RemovedRelativeTransformsFromConnectionComponents,
+
+    // 2018-11-19 OnlineSubsystemMCP - Restore a lost pawn since we didn't have peoples EpicID
+    DROPPED_MCP_RestoreLostPawn,
+
+    // 2018-11-19 Wires no longer save locations, they span between connection components instead
+    DROPPED_WireSpanFromConnnectionComponents,
+
+    // 2019-01-30 Renamed SaveSessionId
+    DROPPED_RenamedSaveSessionId,
+
+    // 2019-06-20 GeoThermal generators didn't save resource nodes prior to this which results with issues when being dismantled
+    ChangedGeoThermalGeneratorSaved,
+
+    // 2019-06-24 NewRailroadSerialization to overwrite old railroad data
+    OverwriteOldRailroadData,
+
+    // 2019-07-24 Due to a bug in the network optimizations the legs data where trashed, reseting the legs to zero is the best option.
+    ResetFactoryLegs,
+
+    // 2019-08-28 The large portion of the save file is now compressed. The header is still intact at the start of the file but after that it is compressed with ZLIB.
+    SaveFileIsCompressed,
+
+    // 2020-02-09: This is so we can check if a save is older than BU3 and do certain migrations.
+    // For example save old number of inventory and arm slots to new system
+    BU3SaveCompatibility,
+
+    // 2020-03-19: Factory Colors have been converted to Linear Color. The buildable subsystem needs to convert from FColor to Linear Color overriding the defaults
+    BuildingColorConversion,
+
+    // 2020-04-21 Lizard doggos that had the friend status set but did not have a valid spawner saved will be recoupled with their spawner so that they are not killed bc of orphan status
+    RescuedFriendDoggos,
+
+    // 2020-06-02 Check if we have saved items in our inventory that is relevant to know if they are picked up
+    CheckPickedUpItems,
+
+    // 2021-02-05 Migrate Building Colros to FCustomUserColorData
+    PerInstanceCustomColors,
+
+    // 2021-09-14 Fix incorrect positioning of double ramp meshes. We then adjust position of double ramps in older saves in order to account for the change.
+    DoubleRampPositioning,
+
+    // 2021-09-21 Migrate FGTrain from native only to a blueprint class BP_Train.
+    TrainBlueprintClassAdded,
+
+    // -----<new versions can be added above this line>-------------------------------------------------
+    VersionPlusOne,
+    LatestVersion = VersionPlusOne - 1
+}

--- a/SatisfactorySaveNet/HeaderSerializer.cs
+++ b/SatisfactorySaveNet/HeaderSerializer.cs
@@ -24,6 +24,12 @@ public class HeaderSerializer : IHeaderSerializer
         var saveVersion = reader.ReadInt32();
         var buildVersion = reader.ReadInt32();
 
+        if (headerVersion > (int)SaveHeaderVersion.LatestVersion)
+            throw new NotSupportedException($"Unsupported header version {headerVersion}. Supported up to {(int)SaveHeaderVersion.LatestVersion}.");
+
+        if (saveVersion < (int)FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents || saveVersion > (int)FSaveCustomVersion.LatestVersion)
+            throw new NotSupportedException($"Unsupported save version {saveVersion}. Supported range {(int)FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents}-{(int)FSaveCustomVersion.LatestVersion}.");
+
         string? saveName = null;
 
         if (headerVersion >= 14)

--- a/SatisfactorySaveNet/SaveHeaderVersion.cs
+++ b/SatisfactorySaveNet/SaveHeaderVersion.cs
@@ -1,0 +1,38 @@
+namespace SatisfactorySaveNet;
+
+public enum SaveHeaderVersion
+{
+    // First version
+    InitialVersion = 0,
+
+    // @2017-01-20: Added BuildVersion, MapName and MapOptions
+    PrepareForLoadingMaps,
+
+    // @2017-02-07: Added SessionId for autosaves
+    AddedSessionId,
+
+    // @2018-02-23 Added PlayDuration to header
+    AddedPlayDuration,
+
+    // @2018-04-10 SessionID from int32 to FString, also added when the save was saved
+    SessionIDStringAndSaveTimeAdded,
+
+    // @2019-01-15 Added session visibility to the header so we can set it up with the same visibility
+    AddedSessionVisibility,
+
+    // @2019-06-19 This was put in the wrong save version thingy and is now on experimental so cant remnove it.
+    LookAtTheComment,
+
+    // @2021-01-22 UE4.25 Engine Upgrade. FEditorObjectVersion Changes occurred (notably with FText serialization)
+    UE425EngineUpdate,
+
+    // @2021-03-24 Added Modding properties and support
+    AddedModdingParams,
+
+    // @2021-04-15 UE4.26 Engine Upgrade. FEditorObjectVersion Changes occurred
+    UE426EngineUpdate,
+
+    // -----<new versions can be added above this line>-----
+    VersionPlusOne,
+    LatestVersion = VersionPlusOne - 1 // Last version to use
+}


### PR DESCRIPTION
## Summary
- add `SaveHeaderVersion` and `FSaveCustomVersion` enums
- validate header and save versions during deserialization
- document supported version range
- test version validation

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a2e8c793c08333b9d9e88e6a6dea69