### PR TITLE
Add build version validation and friendly names

### DIFF
--- a/SatisfactorySaveNet.Abstracts/BuildVersions.cs
+++ b/SatisfactorySaveNet.Abstracts/BuildVersions.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+
+namespace SatisfactorySaveNet.Abstracts;
+
+/// <summary>
+/// Constants for known Satisfactory build versions.
+/// </summary>
+public static class BuildVersions
+{
+    /// <summary>
+    /// First patch of Update 4 on the experimental branch.
+    /// </summary>
+    public const int Patch0400 = 146871;
+
+    /// <summary>
+    /// Update 6 hotfix 0.6.1.3.
+    /// </summary>
+    public const int Patch0613 = 202470;
+
+    /// <summary>
+    /// First experimental release of Update 7.
+    /// </summary>
+    public const int Patch0700 = 208250;
+
+    private static readonly IReadOnlyDictionary<int, string> _names = new Dictionary<int, string>
+    {
+        [Patch0400] = "Update 4 (0.4.0.0)",
+        [Patch0613] = "Patch 0.6.1.3",
+        [Patch0700] = "Patch 0.7.0.0"
+    };
+
+    /// <summary>
+    /// Determines whether the specified build version is known.
+    /// </summary>
+    public static bool IsKnown(int buildVersion) => _names.ContainsKey(buildVersion);
+
+    /// <summary>
+    /// Gets a friendly name for a build version, if available.
+    /// </summary>
+    public static string? GetName(int buildVersion) =>
+        _names.TryGetValue(buildVersion, out var name) ? name : null;
+}

--- a/SatisfactorySaveNet.Abstracts/Model/Header.cs
+++ b/SatisfactorySaveNet.Abstracts/Model/Header.cs
@@ -5,20 +5,27 @@ namespace SatisfactorySaveNet.Abstracts.Model;
 public class Header
 {
     /// <summary>
-    /// For a version list see the header SaveCustomVersion.h in the Community resources <see href="https://satisfactory.fandom.com/wiki/Community_resources">see here</see>
+    /// Version of the header structure.
+    /// See <see cref="SaveHeaderVersion"/> for known values.
     /// </summary>
     public int HeaderVersion { get; set; }
 
     /// <summary>
-    /// For a version list see the header FGSaveManagerInterface.h in the Community resources <see href="https://satisfactory.fandom.com/wiki/Community_resources">see here</see>
+    /// Version of the save serialization format.
+    /// See <see cref="FSaveCustomVersion"/> for known values.
     /// </summary>
     public int SaveVersion { get; set; }
 
-    //ToDo: Review "Seems to always be 66297"
     /// <summary>
-    /// This is Patch <see href="https://satisfactory.fandom.com/wiki/Patch_0.6.1.3">0.6.1.3</see>
+    /// Build number of the game.
+    /// Known builds are listed in <see cref="BuildVersions"/>.
     /// </summary>
     public int BuildVersion { get; set; }
+
+    /// <summary>
+    /// Friendly name of <see cref="BuildVersion"/> if known.
+    /// </summary>
+    public string? BuildVersionName => BuildVersions.GetName(BuildVersion);
 
     /// <summary>
     /// "Persistent_Level"

--- a/SatisfactorySaveNet.Tests/BodySerializerTests.cs
+++ b/SatisfactorySaveNet.Tests/BodySerializerTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using FluentAssertions;
 using SatisfactorySaveNet;
+using SatisfactorySaveNet.Abstracts;
 using SatisfactorySaveNet.Abstracts.Model;
 using SatisfactorySaveNet.Abstracts.Model.Properties;
 using SatisfactorySaveNet.Abstracts.Maths.Vector;
@@ -21,7 +22,7 @@ public class BodySerializerTests
         {
             HeaderVersion = 5,
             SaveVersion = 10,
-            BuildVersion = 1,
+            BuildVersion = BuildVersions.Patch0613,
             MapName = "Map",
             MapOptions = string.Empty,
             SessionName = "Session",
@@ -88,7 +89,7 @@ public class BodySerializerTests
         {
             HeaderVersion = 7,
             SaveVersion = 41,
-            BuildVersion = 1,
+            BuildVersion = BuildVersions.Patch0613,
             MapName = "Map",
             MapOptions = string.Empty,
             SessionName = "Session",
@@ -133,7 +134,7 @@ public class BodySerializerTests
         {
             HeaderVersion = 7,
             SaveVersion = 41,
-            BuildVersion = 1,
+            BuildVersion = BuildVersions.Patch0613,
             MapName = "Map",
             MapOptions = string.Empty,
             SessionName = "Session",
@@ -187,7 +188,7 @@ public class BodySerializerTests
         {
             HeaderVersion = 7,
             SaveVersion = 51,
-            BuildVersion = 1,
+            BuildVersion = BuildVersions.Patch0613,
             MapName = "Map",
             MapOptions = string.Empty,
             SessionName = "Session",

--- a/SatisfactorySaveNet.Tests/HeaderSerializerTests.cs
+++ b/SatisfactorySaveNet.Tests/HeaderSerializerTests.cs
@@ -43,4 +43,22 @@ public class HeaderSerializerTests
         Action act = () => HeaderSerializer.Instance.Deserialize(reader);
         act.Should().Throw<NotSupportedException>().WithMessage("*save version*");
     }
+
+    [Test]
+    public void Deserialize_Throws_ForUnsupportedBuildVersion()
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true))
+        {
+            writer.Write((int)SaveHeaderVersion.InitialVersion);
+            writer.Write((int)FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents);
+            writer.Write(123); // unknown build version
+        }
+
+        stream.Position = 0;
+        using var reader = new BinaryReader(stream);
+
+        Action act = () => HeaderSerializer.Instance.Deserialize(reader);
+        act.Should().Throw<NotSupportedException>().WithMessage("*build version*");
+    }
 }

--- a/SatisfactorySaveNet.Tests/SaveFileSerializerCompressedTests.cs
+++ b/SatisfactorySaveNet.Tests/SaveFileSerializerCompressedTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Compression;
 using FluentAssertions;
 using SatisfactorySaveNet;
+using SatisfactorySaveNet.Abstracts;
 using SatisfactorySaveNet.Abstracts.Exceptions;
 using SatisfactorySaveNet.Abstracts.Model;
 
@@ -18,7 +19,7 @@ public class SaveFileSerializerCompressedTests
         {
             HeaderVersion = 5,
             SaveVersion = 21,
-            BuildVersion = 1,
+            BuildVersion = BuildVersions.Patch0613,
             MapName = "Map",
             MapOptions = string.Empty,
             SessionName = "Session",

--- a/SatisfactorySaveNet.Tests/SaveSerializerTests.cs
+++ b/SatisfactorySaveNet.Tests/SaveSerializerTests.cs
@@ -20,7 +20,7 @@ public class SaveSerializerTests
             {
                 HeaderVersion = 5,
                 SaveVersion = (int)FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents,
-                BuildVersion = 1,
+                BuildVersion = BuildVersions.Patch0613,
                 SaveName = "Test",
                 MapName = "Map",
                 MapOptions = string.Empty,
@@ -48,7 +48,7 @@ public class SaveSerializerTests
             {
                 HeaderVersion = 5,
                 SaveVersion = 21,
-                BuildVersion = 1,
+                BuildVersion = BuildVersions.Patch0613,
                 SaveName = "Test",
                 MapName = "Map",
                 MapOptions = string.Empty,

--- a/SatisfactorySaveNet.Tests/SaveVersion51Tests.cs
+++ b/SatisfactorySaveNet.Tests/SaveVersion51Tests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using FluentAssertions;
 using NUnit.Framework;
 using SatisfactorySaveNet;
+using SatisfactorySaveNet.Abstracts;
 using SatisfactorySaveNet.Abstracts.Model;
 
 namespace SatisfactorySaveNet.Tests;
@@ -18,7 +19,7 @@ public class SaveVersion51Tests
         {
             HeaderVersion = 14,
             SaveVersion = 51,
-            BuildVersion = 1,
+            BuildVersion = BuildVersions.Patch0613,
             SaveName = "TestSave",
             MapName = "Map",
             MapOptions = "options",
@@ -105,7 +106,7 @@ public class SaveVersion51Tests
             {
                 HeaderVersion = 14,
                 SaveVersion = 51,
-                BuildVersion = 1,
+                BuildVersion = BuildVersions.Patch0613,
                 SaveName = "TestSave",
                 MapName = "Map",
                 MapOptions = string.Empty,

--- a/SatisfactorySaveNet/HeaderSerializer.cs
+++ b/SatisfactorySaveNet/HeaderSerializer.cs
@@ -30,6 +30,9 @@ public class HeaderSerializer : IHeaderSerializer
         if (saveVersion < (int)FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents || saveVersion > (int)FSaveCustomVersion.LatestVersion)
             throw new NotSupportedException($"Unsupported save version {saveVersion}. Supported range {(int)FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents}-{(int)FSaveCustomVersion.LatestVersion}.");
 
+        if (!BuildVersions.IsKnown(buildVersion))
+            throw new NotSupportedException($"Unsupported build version {buildVersion}.");
+
         string? saveName = null;
 
         if (headerVersion >= 14)
@@ -84,6 +87,10 @@ public class HeaderSerializer : IHeaderSerializer
     {
         writer.Write(header.HeaderVersion);
         writer.Write(header.SaveVersion);
+
+        if (!BuildVersions.IsKnown(header.BuildVersion))
+            throw new NotSupportedException($"Unsupported build version {header.BuildVersion}.");
+
         writer.Write(header.BuildVersion);
 
         if (header.HeaderVersion >= 14)


### PR DESCRIPTION
## Summary
- define known Satisfactory build versions and patch names
- validate build version during header (de)serialization and expose friendly name
- clean up header XML docs and align tests with new build version constants

## Testing
- `dotnet test` *(fails: Unsupported header version, unknown object type, BodyV8 serialization only supports a single persistent level)*

------
https://chatgpt.com/codex/tasks/task_e_68a35a6dbee88333aa60bd2ee0cc0840