### PR TITLE
Use new save version endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You can integrate it using [nuget.org](https://www.nuget.org/packages/Satisfacto
 Further, (external and promising looking) documentation of the save game format is available [here](https://github.com/moritz-h/satisfactory-3d-map/blob/master/docs/SATISFACTORY_SAVE.md). **Link fixed now sorry**
 
 ## Version compatibility
-The library supports save headers up to `SaveHeaderVersion.LatestVersion` and save versions from `FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents` through `FSaveCustomVersion.LatestVersion`. Newer or older saves outside of this range will result in a `NotSupportedException` during deserialization.
+The library supports save headers up to `SaveHeaderVersion.VersionPlusOne - 1` and save versions from `FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents` through `FSaveCustomVersion.VersionPlusOne - 1`. Newer or older saves outside of this range will result in a `NotSupportedException` during deserialization.
 
 ## How to use
 ```CSharp

--- a/SatisfactorySaveNet.Tests/HeaderSerializerTests.cs
+++ b/SatisfactorySaveNet.Tests/HeaderSerializerTests.cs
@@ -14,7 +14,7 @@ public class HeaderSerializerTests
         using var stream = new MemoryStream();
         using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true))
         {
-            writer.Write((int)SaveHeaderVersion.LatestVersion + 1);
+            writer.Write((int)SaveHeaderVersion.VersionPlusOne);
             writer.Write((int)FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents);
             writer.Write(0);
         }
@@ -32,8 +32,8 @@ public class HeaderSerializerTests
         using var stream = new MemoryStream();
         using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true))
         {
-            writer.Write((int)SaveHeaderVersion.LatestVersion);
-            writer.Write((int)FSaveCustomVersion.LatestVersion + 1);
+            writer.Write((int)SaveHeaderVersion.VersionPlusOne - 1);
+            writer.Write((int)FSaveCustomVersion.VersionPlusOne);
             writer.Write(0);
         }
 

--- a/SatisfactorySaveNet.Tests/SaveVersion52PlusTests.cs
+++ b/SatisfactorySaveNet.Tests/SaveVersion52PlusTests.cs
@@ -3,12 +3,13 @@ using System.IO;
 using FluentAssertions;
 using NUnit.Framework;
 using SatisfactorySaveNet;
+using SatisfactorySaveNet.Abstracts;
 using SatisfactorySaveNet.Abstracts.Model;
 
 namespace SatisfactorySaveNet.Tests;
 
-[TestFixture(52, 1)]
-[TestFixture(53, 1)]
+[TestFixture(52, BuildVersions.Patch0700)]
+[TestFixture(53, BuildVersions.Patch0700)]
 [Parallelizable(ParallelScope.All)]
 public class SaveVersion52PlusTests
 {

--- a/SatisfactorySaveNet/HeaderSerializer.cs
+++ b/SatisfactorySaveNet/HeaderSerializer.cs
@@ -24,11 +24,11 @@ public class HeaderSerializer : IHeaderSerializer
         var saveVersion = reader.ReadInt32();
         var buildVersion = reader.ReadInt32();
 
-        if (headerVersion > (int)SaveHeaderVersion.LatestVersion)
-            throw new NotSupportedException($"Unsupported header version {headerVersion}. Supported up to {(int)SaveHeaderVersion.LatestVersion}.");
+        if (headerVersion >= (int)SaveHeaderVersion.VersionPlusOne)
+            throw new NotSupportedException($"Unsupported header version {headerVersion}. Supported up to {(int)SaveHeaderVersion.VersionPlusOne - 1}.");
 
-        if (saveVersion < (int)FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents || saveVersion > (int)FSaveCustomVersion.LatestVersion)
-            throw new NotSupportedException($"Unsupported save version {saveVersion}. Supported range {(int)FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents}-{(int)FSaveCustomVersion.LatestVersion}.");
+        if (saveVersion < (int)FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents || saveVersion >= (int)FSaveCustomVersion.VersionPlusOne)
+            throw new NotSupportedException($"Unsupported save version {saveVersion}. Supported range {(int)FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents}-{(int)FSaveCustomVersion.VersionPlusOne - 1}.");
 
         if (!BuildVersions.IsKnown(buildVersion))
             throw new NotSupportedException($"Unsupported build version {buildVersion}.");
@@ -55,8 +55,8 @@ public class HeaderSerializer : IHeaderSerializer
 
         //ToDo: Set flag to inform about possible loss of information due to deprecated reader
 
-        //if (header.HeaderVersion > SaveHeaderVersion.LatestVersion)
-        //if (header.SaveVersion < FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents || header.SaveVersion > FSaveCustomVersion.LatestVersion)
+        //if (header.HeaderVersion >= SaveHeaderVersion.VersionPlusOne)
+        //if (header.SaveVersion < FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents || header.SaveVersion >= FSaveCustomVersion.VersionPlusOne)
 
         if (header.HeaderVersion >= 5)
             header.SessionVisibility = reader.ReadByte();


### PR DESCRIPTION
## Summary
- update header serializer to new SaveHeaderVersion.VersionPlusOne and FSaveCustomVersion.VersionPlusOne endpoints
- adjust tests and docs for new max version constants
- ensure round-trip tests use a valid build version

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a35e7613088333836c8ed83c950f44