### PR TITLE
Fix mod path detection for helper methods

### DIFF
--- a/SatisfactorySaveNet.Tests/KnownConstantsTests.cs
+++ b/SatisfactorySaveNet.Tests/KnownConstantsTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using SatisfactorySaveNet;
+
+namespace SatisfactorySaveNet.Tests;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class KnownConstantsTests
+{
+    [Test]
+    public void IsConveyorLift_ModPath_ReturnsTrue()
+    {
+        var path = "/Conveyors_Mod/Build_LiftMk1.Build_LiftMk1_C_Extra";
+        KnownConstants.IsConveyorLift(path).Should().BeTrue();
+    }
+
+    [Test]
+    public void IsConveyorBelt_ModPath_ReturnsTrue()
+    {
+        var path = "/Conveyors_Mod/Build_BeltMk1.Build_BeltMk1_C_Extra";
+        KnownConstants.IsConveyorBelt(path).Should().BeTrue();
+    }
+
+    [Test]
+    public void IsPowerLine_ModPath_ReturnsTrue()
+    {
+        var path = "/FlexSplines/PowerLine/Build_FlexPowerline.Build_FlexPowerline_C_Extra";
+        KnownConstants.IsPowerLine(path).Should().BeTrue();
+    }
+
+    [Test]
+    public void IsVehicle_ModPath_ReturnsTrue()
+    {
+        var path = "/x3_mavegrag/Vehicles/Trucks/TruckMk1/BP_X3Truck_Mk1.BP_X3Truck_Mk1_C_Extra";
+        KnownConstants.IsVehicle(path).Should().BeTrue();
+    }
+
+    [Test]
+    public void IsLocomotive_ModPath_ReturnsTrue()
+    {
+        var path = "/x3_mavegrag/Vehicles/Trains/Locomotive_Mk1/BP_X3Locomotive_Mk1.BP_X3Locomotive_Mk1_C_Extra";
+        KnownConstants.IsLocomotive(path).Should().BeTrue();
+    }
+
+    [Test]
+    public void IsFreightWagon_ModPath_ReturnsTrue()
+    {
+        var path = "/x3_mavegrag/Vehicles/Trains/CargoWagon_Mk1/BP_X3CargoWagon_Mk1.BP_X3CargoWagon_Mk1_C_Extra";
+        KnownConstants.IsFreightWagon(path).Should().BeTrue();
+    }
+}

--- a/SatisfactorySaveNet/KnownConstants.cs
+++ b/SatisfactorySaveNet/KnownConstants.cs
@@ -131,12 +131,12 @@ public static class KnownConstants
 
     public static bool IsConveyorLift(string path)
     {
-        return ConveyorLifts.Contains(path) || ModConveyorLifts.Any(x => x.StartsWith(path, StringComparison.Ordinal));
+        return ConveyorLifts.Contains(path) || ModConveyorLifts.Any(x => path.StartsWith(x, StringComparison.Ordinal));
     }
 
     public static bool IsConveyorBelt(string path)
     {
-        return ConveyorBelts.Contains(path) || ModConveyorBelts.Any(x => x.StartsWith(path, StringComparison.Ordinal));
+        return ConveyorBelts.Contains(path) || ModConveyorBelts.Any(x => path.StartsWith(x, StringComparison.Ordinal));
     }
 
     public static bool IsConveyorActor(string path)
@@ -151,21 +151,21 @@ public static class KnownConstants
 
     public static bool IsPowerLine(string path)
     {
-        return PowerLines.Contains(path) || ModPowerLines.Any(x => x.StartsWith(path, StringComparison.Ordinal));
+        return PowerLines.Contains(path) || ModPowerLines.Any(x => path.StartsWith(x, StringComparison.Ordinal));
     }
 
     public static bool IsVehicle(string path)
     {
-        return Vehicles.Contains(path) || ModVehicles.Any(x => x.StartsWith(path, StringComparison.Ordinal));
+        return Vehicles.Contains(path) || ModVehicles.Any(x => path.StartsWith(x, StringComparison.Ordinal));
     }
 
     public static bool IsLocomotive(string path)
     {
-        return Locomotives.Contains(path) || ModLocomotives.Any(x => x.StartsWith(path, StringComparison.Ordinal));
+        return Locomotives.Contains(path) || ModLocomotives.Any(x => path.StartsWith(x, StringComparison.Ordinal));
     }
 
     public static bool IsFreightWagon(string path)
     {
-        return FreightWagon.Contains(path) || ModFreightWagon.Any(x => x.StartsWith(path, StringComparison.Ordinal));
+        return FreightWagon.Contains(path) || ModFreightWagon.Any(x => path.StartsWith(x, StringComparison.Ordinal));
     }
 }


### PR DESCRIPTION
## Summary
- check path prefixes when detecting modded conveyor lifts, belts, power lines, vehicles, locomotives, and freight wagons
- add unit tests ensuring modded paths are recognized

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a3c22d4de88333aec311914909b7ab