### PR TITLE
Remove BGU_Subsystem special-case from PropertySerializer

### DIFF
--- a/SatisfactorySaveNet.Abstracts/Model/Union/ObjectReferenceUnion.cs
+++ b/SatisfactorySaveNet.Abstracts/Model/Union/ObjectReferenceUnion.cs
@@ -4,10 +4,4 @@ public class ObjectReferenceUnion : UnionBase
 {
     public override UnionConstraint Type => UnionConstraint.ObjectReference;
     public ObjectReference Value { get; set; } = new();
-
-    public float Unknown1 { get; set; }
-    public float Unknown2 { get; set; }
-    public float Unknown3 { get; set; }
-    public float Unknown4 { get; set; }
-    public string Unknown5 { get; set; } = string.Empty;
 }

--- a/SatisfactorySaveNet.Abstracts/Model/Union/StrUnion.cs
+++ b/SatisfactorySaveNet.Abstracts/Model/Union/StrUnion.cs
@@ -4,8 +4,4 @@ public class StrUnion : UnionBase
 {
     public override UnionConstraint Type => UnionConstraint.Str;
     public string Value { get; set; } = string.Empty;
-
-    public float Unknown1 { get; set; }
-    public float Unknown2 { get; set; }
-    public float Unknown3 { get; set; }
 }

--- a/SatisfactorySaveNet.Tests/PropertySerializerMapTests.cs
+++ b/SatisfactorySaveNet.Tests/PropertySerializerMapTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using NUnit.Framework;
+using SatisfactorySaveNet;
+using SatisfactorySaveNet.Abstracts;
+using SatisfactorySaveNet.Abstracts.Model;
+using SatisfactorySaveNet.Abstracts.Model.Properties;
+using SatisfactorySaveNet.Abstracts.Model.Union;
+using System.IO;
+using System.Linq;
+
+namespace SatisfactorySaveNet.Tests;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class PropertySerializerMapTests
+{
+    private readonly IPropertySerializer _serializer = PropertySerializer.Instance;
+    private readonly Header _header = new();
+
+    [Test]
+    public void Deserialize_MapProperty_WithStringValue()
+    {
+        using var ms = new MemoryStream();
+        using var writer = new BinaryWriter(ms);
+        StringSerializer.Instance.Serialize(writer, "MyMap");
+        StringSerializer.Instance.Serialize(writer, nameof(MapProperty));
+        writer.Write(0); // binarySize
+        writer.Write(0); // index
+        StringSerializer.Instance.Serialize(writer, nameof(IntProperty)); // key type
+        StringSerializer.Instance.Serialize(writer, nameof(StrProperty)); // value type
+        writer.Write((sbyte)0); // padding
+        writer.Write(0); // modeType
+        writer.Write(1); // count
+        writer.Write(123); // key
+        StringSerializer.Instance.Serialize(writer, "Hello"); // value
+        ms.Position = 0;
+
+        var property = (MapProperty)_serializer.DeserializeProperty(new BinaryReader(ms), _header)!;
+        var element = property.Elements.Single();
+        element.Key.Should().BeOfType<IntUnion>().Which.Value.Should().Be(123);
+        element.Value.Should().BeOfType<StrUnion>().Which.Value.Should().Be("Hello");
+    }
+}

--- a/SatisfactorySaveNet/PropertySerializer.cs
+++ b/SatisfactorySaveNet/PropertySerializer.cs
@@ -801,11 +801,6 @@ public class PropertySerializer : IPropertySerializer
                             : new Vector3Union { Value = _vectorSerializer.DeserializeVec3(reader) };
                         break;
                     }
-                    if (string.Equals(type, "/BuildGunUtilities/BGU_Subsystem.BGU_Subsystem_C", StringComparison.Ordinal)) //ToDo: Debug?
-                    {
-                        key = new Vector3Union { Value = _vectorSerializer.DeserializeVec3(reader) };
-                        break;
-                    }
                     if (string.Equals(propertyName, "mSaveData", StringComparison.Ordinal) || string.Equals(propertyName, "mUnresolvedSaveData", StringComparison.Ordinal))
                     {
                         key = new Vector3IUnion { Value = _vectorSerializer.DeserializeVec3I(reader) };
@@ -837,14 +832,10 @@ public class PropertySerializer : IPropertySerializer
                     value = new FloatUnion { Value = reader.ReadSingle() };
                     break;
                 case nameof(StrProperty):
-                    value = string.Equals(type, "/BuildGunUtilities/BGU_Subsystem.BGU_Subsystem_C", StringComparison.Ordinal)
-                        ? new StrUnion { Unknown1 = reader.ReadSingle(), Unknown2 = reader.ReadSingle(), Unknown3 = reader.ReadSingle(), Value = _stringSerializer.Deserialize(reader) }
-                        : null;
+                    value = new StrUnion { Value = _stringSerializer.Deserialize(reader) };
                     break;
                 case nameof(ObjectProperty):
-                    value = string.Equals(type, "/BuildGunUtilities/BGU_Subsystem.BGU_Subsystem_C", StringComparison.Ordinal)
-                        ? new ObjectReferenceUnion { Unknown1 = reader.ReadSingle(), Unknown2 = reader.ReadSingle(), Unknown3 = reader.ReadSingle(), Unknown4 = reader.ReadSingle(), Unknown5 = _stringSerializer.Deserialize(reader) }
-                        : new ObjectReferenceUnion { Value = _objectReferenceSerializer.Deserialize(reader) };
+                    value = new ObjectReferenceUnion { Value = _objectReferenceSerializer.Deserialize(reader) };
                     break;
                 case nameof(TextProperty):
                     value = new TextUnion { Value = DeserializeTextProperty(reader, header) };


### PR DESCRIPTION
## Summary
- drop unused BuildGunUtilities special-case from map deserialization
- remove extra fields from StrUnion and ObjectReferenceUnion
- add MapProperty deserialization test

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a3c46782308333ad80abc9a4e08dde