### PR TITLE
Add deprecated flag for unsupported save headers

### DIFF
--- a/SatisfactorySaveNet.Abstracts/Model/Header.cs
+++ b/SatisfactorySaveNet.Abstracts/Model/Header.cs
@@ -23,6 +23,12 @@ public class Header
     public int BuildVersion { get; set; }
 
     /// <summary>
+    /// Indicates whether the save header or version is not fully supported
+    /// by the current serializer.
+    /// </summary>
+    public bool IsDeprecated { get; set; }
+
+    /// <summary>
     /// Friendly name of <see cref="BuildVersion"/> if known.
     /// </summary>
     public string? BuildVersionName => BuildVersions.GetName(BuildVersion);

--- a/SatisfactorySaveNet.Tests/HeaderSerializerTests.cs
+++ b/SatisfactorySaveNet.Tests/HeaderSerializerTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using FluentAssertions;
+using SatisfactorySaveNet.Abstracts;
+using SatisfactorySaveNet.Abstracts.Model;
 
 namespace SatisfactorySaveNet.Tests;
 
@@ -9,39 +11,77 @@ namespace SatisfactorySaveNet.Tests;
 public class HeaderSerializerTests
 {
     [Test]
-    public void Deserialize_Throws_ForTooNewHeaderVersion()
+    public void Deserialize_SetsFlag_ForTooNewHeaderVersion()
     {
+        var header = new Header
+        {
+            HeaderVersion = (int)SaveHeaderVersion.VersionPlusOne,
+            SaveVersion = (int)FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents,
+            BuildVersion = BuildVersions.Patch0613,
+            SaveName = string.Empty,
+            MapName = string.Empty,
+            MapOptions = string.Empty,
+            SessionName = string.Empty,
+            PlayedSeconds = 0,
+            SaveDateTimeUtc = DateTime.UnixEpoch,
+            SessionVisibility = 0,
+            EditorObjectVersion = 0,
+            ModMetadata = string.Empty,
+            IsModdedSave = 0,
+            SaveIdentifier = string.Empty,
+            IsPartitionedWorld = 0,
+            SaveDataHash = new string('0', 20),
+            IsCreativeModeEnabled = 0
+        };
+
         using var stream = new MemoryStream();
         using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true))
         {
-            writer.Write((int)SaveHeaderVersion.VersionPlusOne);
-            writer.Write((int)FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents);
-            writer.Write(0);
+            HeaderSerializer.Instance.Serialize(writer, header);
         }
 
         stream.Position = 0;
         using var reader = new BinaryReader(stream);
+        var result = HeaderSerializer.Instance.Deserialize(reader);
 
-        Action act = () => HeaderSerializer.Instance.Deserialize(reader);
-        act.Should().Throw<NotSupportedException>().WithMessage("*header version*");
+        result.IsDeprecated.Should().BeTrue();
     }
 
     [Test]
-    public void Deserialize_Throws_ForUnsupportedSaveVersion()
+    public void Deserialize_SetsFlag_ForUnsupportedSaveVersion()
     {
+        var header = new Header
+        {
+            HeaderVersion = (int)SaveHeaderVersion.VersionPlusOne - 1,
+            SaveVersion = (int)FSaveCustomVersion.VersionPlusOne,
+            BuildVersion = BuildVersions.Patch0613,
+            SaveName = string.Empty,
+            MapName = string.Empty,
+            MapOptions = string.Empty,
+            SessionName = string.Empty,
+            PlayedSeconds = 0,
+            SaveDateTimeUtc = DateTime.UnixEpoch,
+            SessionVisibility = 0,
+            EditorObjectVersion = 0,
+            ModMetadata = string.Empty,
+            IsModdedSave = 0,
+            SaveIdentifier = string.Empty,
+            IsPartitionedWorld = 0,
+            SaveDataHash = new string('0', 20),
+            IsCreativeModeEnabled = 0
+        };
+
         using var stream = new MemoryStream();
         using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true))
         {
-            writer.Write((int)SaveHeaderVersion.VersionPlusOne - 1);
-            writer.Write((int)FSaveCustomVersion.VersionPlusOne);
-            writer.Write(0);
+            HeaderSerializer.Instance.Serialize(writer, header);
         }
 
         stream.Position = 0;
         using var reader = new BinaryReader(stream);
+        var result = HeaderSerializer.Instance.Deserialize(reader);
 
-        Action act = () => HeaderSerializer.Instance.Deserialize(reader);
-        act.Should().Throw<NotSupportedException>().WithMessage("*save version*");
+        result.IsDeprecated.Should().BeTrue();
     }
 
     [Test]

--- a/SatisfactorySaveNet/HeaderSerializer.cs
+++ b/SatisfactorySaveNet/HeaderSerializer.cs
@@ -24,11 +24,10 @@ public class HeaderSerializer : IHeaderSerializer
         var saveVersion = reader.ReadInt32();
         var buildVersion = reader.ReadInt32();
 
-        if (headerVersion >= (int)SaveHeaderVersion.VersionPlusOne)
-            throw new NotSupportedException($"Unsupported header version {headerVersion}. Supported up to {(int)SaveHeaderVersion.VersionPlusOne - 1}.");
-
-        if (saveVersion < (int)FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents || saveVersion >= (int)FSaveCustomVersion.VersionPlusOne)
-            throw new NotSupportedException($"Unsupported save version {saveVersion}. Supported range {(int)FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents}-{(int)FSaveCustomVersion.VersionPlusOne - 1}.");
+        var isDeprecated =
+            headerVersion >= (int)SaveHeaderVersion.VersionPlusOne ||
+            saveVersion < (int)FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents ||
+            saveVersion >= (int)FSaveCustomVersion.VersionPlusOne;
 
         if (!BuildVersions.IsKnown(buildVersion))
             throw new NotSupportedException($"Unsupported build version {buildVersion}.");
@@ -43,6 +42,7 @@ public class HeaderSerializer : IHeaderSerializer
             HeaderVersion = headerVersion,
             SaveVersion = saveVersion,
             BuildVersion = buildVersion,
+            IsDeprecated = isDeprecated,
             SaveName = saveName,
 
             MapName = _stringSerializer.Deserialize(reader),
@@ -52,11 +52,6 @@ public class HeaderSerializer : IHeaderSerializer
             PlayedSeconds = reader.ReadInt32(),
             SaveDateTimeUtc = new DateTime(reader.ReadInt64(), DateTimeKind.Utc),
         };
-
-        //ToDo: Set flag to inform about possible loss of information due to deprecated reader
-
-        //if (header.HeaderVersion >= SaveHeaderVersion.VersionPlusOne)
-        //if (header.SaveVersion < FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents || header.SaveVersion >= FSaveCustomVersion.VersionPlusOne)
 
         if (header.HeaderVersion >= 5)
             header.SessionVisibility = reader.ReadByte();


### PR DESCRIPTION
## Summary
- add `IsDeprecated` flag to header model
- mark headers as deprecated when encountering unsupported header or save versions
- test deserialization of deprecated header and save versions

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c477f0008333a2fcd545630c37b8