### PR TITLE
Add async save file serialization methods

### DIFF
--- a/SatisfactorySaveNet.Abstracts/ISaveFileSerializer.cs
+++ b/SatisfactorySaveNet.Abstracts/ISaveFileSerializer.cs
@@ -1,5 +1,6 @@
 ﻿using SatisfactorySaveNet.Abstracts.Model;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace SatisfactorySaveNet.Abstracts;
 
@@ -9,12 +10,18 @@ public interface ISaveFileSerializer
     public SatisfactorySave Deserialize(Stream stream);
     public SatisfactorySave Deserialize(string path);
 
+    public Task<SatisfactorySave> DeserializeAsync(byte[] data);
+    public Task<SatisfactorySave> DeserializeAsync(Stream stream);
+    public Task<SatisfactorySave> DeserializeAsync(string path);
+
     /// <summary>
     /// Serializes a save game to the provided <see cref="Stream"/>.
     /// </summary>
     /// <param name="save">The save structure to serialize.</param>
     /// <param name="stream">Target stream.</param>
     void Serialize(SatisfactorySave save, Stream stream);
+
+    Task SerializeAsync(SatisfactorySave save, Stream stream);
 
     /// <summary>
     /// Serializes a save game and writes it to the specified file path.
@@ -23,10 +30,14 @@ public interface ISaveFileSerializer
     /// <param name="path">Destination file path.</param>
     void Serialize(SatisfactorySave save, string path);
 
+    Task SerializeAsync(SatisfactorySave save, string path);
+
     /// <summary>
     /// Serializes a save game and returns the resulting byte array.
     /// </summary>
     /// <param name="save">The save structure to serialize.</param>
     /// <returns>Binary representation of the save game.</returns>
     byte[] Serialize(SatisfactorySave save);
+
+    Task<byte[]> SerializeAsync(SatisfactorySave save);
 }

--- a/SatisfactorySaveNet.Tests/SaveFileSerializerCompressedTests.cs
+++ b/SatisfactorySaveNet.Tests/SaveFileSerializerCompressedTests.cs
@@ -6,6 +6,7 @@ using SatisfactorySaveNet;
 using SatisfactorySaveNet.Abstracts;
 using SatisfactorySaveNet.Abstracts.Exceptions;
 using SatisfactorySaveNet.Abstracts.Model;
+using System.Threading.Tasks;
 
 namespace SatisfactorySaveNet.Tests;
 
@@ -80,20 +81,34 @@ public class SaveFileSerializerCompressedTests
         return stream.ToArray();
     }
 
-    [Test]
-    public void Deserialize_Compressed_Save()
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task Deserialize_Compressed_Save(bool async)
     {
         var data = CreateCompressedSave();
-        var save = SaveFileSerializer.Instance.Deserialize(data);
+        SatisfactorySave save;
+        if (async)
+            save = await SaveFileSerializer.Instance.DeserializeAsync(data);
+        else
+            save = SaveFileSerializer.Instance.Deserialize(data);
         save.Header.SaveVersion.Should().Be(21);
         save.Body.Should().BeOfType<BodyPreV8>();
     }
 
-    [Test]
-    public void Deserialize_Corrupted_Chunk_Throws()
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task Deserialize_Corrupted_Chunk_Throws(bool async)
     {
         var data = CreateCompressedSave(corrupt: true);
-        var act = () => SaveFileSerializer.Instance.Deserialize(data);
-        act.Should().Throw<CorruptedSatisFactorySaveFileException>();
+        if (async)
+        {
+            var act = async () => await SaveFileSerializer.Instance.DeserializeAsync(data);
+            await act.Should().ThrowAsync<CorruptedSatisFactorySaveFileException>();
+        }
+        else
+        {
+            var act = () => SaveFileSerializer.Instance.Deserialize(data);
+            act.Should().Throw<CorruptedSatisFactorySaveFileException>();
+        }
     }
 }

--- a/SatisfactorySaveNet.Tests/SaveSerializerTests.cs
+++ b/SatisfactorySaveNet.Tests/SaveSerializerTests.cs
@@ -2,6 +2,7 @@ using SatisfactorySaveNet.Abstracts;
 using SatisfactorySaveNet.Abstracts.Model;
 using FluentAssertions;
 using System;
+using System.Threading.Tasks;
 
 namespace SatisfactorySaveNet.Tests;
 
@@ -11,8 +12,9 @@ public class SaveSerializerTests
 {
     private readonly ISaveFileSerializer _serializer = SaveFileSerializer.Instance;
 
-    [Test]
-    public void Serialize_Then_Deserialize_Roundtrip()
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task Serialize_Then_Deserialize_Roundtrip(bool async)
     {
         var save = new SatisfactorySave
         {
@@ -32,15 +34,25 @@ public class SaveSerializerTests
             Body = new BodyPreV8()
         };
 
-        var data = _serializer.Serialize(save);
-        var result = _serializer.Deserialize(data);
+        SatisfactorySave result;
+        if (async)
+        {
+            var data = await _serializer.SerializeAsync(save);
+            result = await _serializer.DeserializeAsync(data);
+        }
+        else
+        {
+            var data = _serializer.Serialize(save);
+            result = _serializer.Deserialize(data);
+        }
 
         result.Header.SaveVersion.Should().Be(save.Header.SaveVersion);
         result.Body.Should().BeOfType<BodyPreV8>();
     }
 
-    [Test]
-    public void Serialize_Then_Deserialize_Roundtrip_Compressed()
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task Serialize_Then_Deserialize_Roundtrip_Compressed(bool async)
     {
         var save = new SatisfactorySave
         {
@@ -60,8 +72,17 @@ public class SaveSerializerTests
             Body = new BodyPreV8()
         };
 
-        var data = _serializer.Serialize(save);
-        var result = _serializer.Deserialize(data);
+        SatisfactorySave result;
+        if (async)
+        {
+            var data = await _serializer.SerializeAsync(save);
+            result = await _serializer.DeserializeAsync(data);
+        }
+        else
+        {
+            var data = _serializer.Serialize(save);
+            result = _serializer.Deserialize(data);
+        }
 
         result.Header.SaveVersion.Should().Be(save.Header.SaveVersion);
         result.Body.Should().BeOfType<BodyPreV8>();

--- a/SatisfactorySaveNet/SaveFileSerializer.cs
+++ b/SatisfactorySaveNet/SaveFileSerializer.cs
@@ -5,6 +5,7 @@ using SatisfactorySaveNet.Abstracts.Model;
 using System;
 using System.IO;
 using System.IO.Compression;
+using System.Threading.Tasks;
 
 namespace SatisfactorySaveNet;
 
@@ -132,6 +133,28 @@ public class SaveFileSerializer : ISaveFileSerializer
         }; //ToDo: Versioned models && include discarded reads
     }
 
+    public async Task<SatisfactorySave> DeserializeAsync(string path)
+    {
+        await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 4096, true);
+        return await DeserializeAsync(stream).ConfigureAwait(false);
+    }
+
+    public async Task<SatisfactorySave> DeserializeAsync(byte[] data)
+    {
+        using var stream = Manager.GetStream(data);
+        return await DeserializeAsync(stream).ConfigureAwait(false);
+    }
+
+    public async Task<SatisfactorySave> DeserializeAsync(Stream stream)
+    {
+        using var buffer = Manager.GetStream();
+        await stream.CopyToAsync(buffer).ConfigureAwait(false);
+        if (buffer.Length == 0)
+            throw new CorruptedSatisFactorySaveFileException("Save file is empty");
+        buffer.Position = 0;
+        return Deserialize(buffer);
+    }
+
     public void Serialize(SatisfactorySave save, string path)
     {
         using var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
@@ -228,5 +251,26 @@ public class SaveFileSerializer : ISaveFileSerializer
 
             compressed.CopyTo(stream);
         }
+    }
+
+    public async Task SerializeAsync(SatisfactorySave save, Stream stream)
+    {
+        using var buffer = Manager.GetStream();
+        Serialize(save, buffer);
+        buffer.Position = 0;
+        await buffer.CopyToAsync(stream).ConfigureAwait(false);
+    }
+
+    public async Task SerializeAsync(SatisfactorySave save, string path)
+    {
+        await using var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true);
+        await SerializeAsync(save, stream).ConfigureAwait(false);
+    }
+
+    public async Task<byte[]> SerializeAsync(SatisfactorySave save)
+    {
+        using var stream = Manager.GetStream();
+        await SerializeAsync(save, stream).ConfigureAwait(false);
+        return stream.ToArray();
     }
 }


### PR DESCRIPTION
## Summary
- extend save file serializer interface with async overloads
- implement async stream and file handling in `SaveFileSerializer`
- exercise synchronous and asynchronous paths in tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c4a733888333b84d6f7fcd0bf837