### PR TITLE
fix: correct abstract package name in workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -33,7 +33,7 @@ jobs:
       uses: alirezanet/publish-nuget@v3.1.0
       with:
         PROJECT_FILE_PATH: ./SatisfactorySaveNet.Abstracts/SatisfactorySaveNet.Abstracts.csproj
-        PACKAGE_NAME: SatisfactorySaveNet
+        PACKAGE_NAME: SatisfactorySaveNet.Abstracts
         VERSION_STATIC: 3.1.0
         TAG_COMMIT: false
         NUGET_KEY: ${{secrets.NUGET_API_KEY}}


### PR DESCRIPTION
## Summary
- use correct package name for Abstracts project in NuGet publish step

## Testing
- `dotnet test` *(fails: ParseMetadata/GetAssemblyVersion/BuildMetadata not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cf461b908333bd33274e3b163bdf