### PR TITLE
docs: expand usage and install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,72 @@ You can integrate it using [nuget.org](https://www.nuget.org/packages/Satisfacto
 
 Further, (external and promising looking) documentation of the save game format is available [here](https://github.com/moritz-h/satisfactory-3d-map/blob/master/docs/SATISFACTORY_SAVE.md). **Link fixed now sorry**
 
+## Installation
+Install the library from [NuGet](https://www.nuget.org/packages/SatisfactorySaveNet/) using your preferred method.
+
+### .NET CLI
+```bash
+dotnet add package SatisfactorySaveNet
+```
+
+### Package Manager
+```powershell
+Install-Package SatisfactorySaveNet
+```
+
+### Project File
+```xml
+<PackageReference Include="SatisfactorySaveNet" Version="3.1.0" />
+```
+
 ## Version compatibility
-The library supports save headers up to `SaveHeaderVersion.SaveNameInHeader` and save versions from `FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents` through `FSaveCustomVersion.TrainBlueprintClassAdded`. Saves outside of this range throw a `NotSupportedException` during deserialization.
 
-## How to use
-```CSharp
+| Component      | Supported versions                                                                 |
+| -------------- | ----------------------------------------------------------------------------------- |
+| Save header    | up to `SaveHeaderVersion.SaveNameInHeader`                                         |
+| Save format    | `FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents` – `FSaveCustomVersion.TrainBlueprintClassAdded` |
+
+Saves outside of these ranges throw a `NotSupportedException` during deserialization.
+
+## Common serialization/deserialization scenarios
+
+### From file
+```csharp
 ISaveFileSerializer serializer = SaveFileSerializer.Instance;
-var saveGame = serializer.Deserialize(@"C:\\mySaveFile.sav");
-serializer.Serialize(saveGame, @"C:\\myNewSaveFile.sav");
+var save = serializer.Deserialize(@"C:\\mySaveFile.sav");
+serializer.Serialize(save, @"C:\\myNewSaveFile.sav");
 ```
 
-## Injection example
-```CSharp
-ISaveFileSerializer Instance = new SaveFileSerializer(HeaderSerializer.Instance, ChunkSerializer.Instance, BodySerializer.Instance);
+### From byte array
+```csharp
+var save = serializer.Deserialize(fileBytes);
+var bytes = serializer.Serialize(save);
 ```
+
+### Using streams
+```csharp
+using var readStream = File.OpenRead(@"C:\\mySaveFile.sav");
+var save = serializer.Deserialize(readStream);
+using var writeStream = File.Create(@"C:\\myNewSaveFile.sav");
+serializer.Serialize(save, writeStream);
+```
+
+### Asynchronous
+```csharp
+var save = await serializer.DeserializeAsync(@"C:\\mySaveFile.sav");
+await serializer.SerializeAsync(save, @"C:\\myNewSaveFile.sav");
+```
+
+## Configuration options
+`SaveFileSerializer` accepts injectable components, allowing you to override specific parts of the pipeline:
+
+```csharp
+var serializer = new SaveFileSerializer(
+    HeaderSerializer.Instance,
+    ChunkSerializer.Instance,
+    BodySerializer.Instance);
+```
+
+- Replace `IHeaderSerializer`, `IChunkSerializer`, or `IBodySerializer` with custom implementations to handle experimental features or logging.
+- Choose between synchronous and asynchronous APIs depending on your workload.
+


### PR DESCRIPTION
## Summary
- add NuGet installation commands
- show supported save versions in a table
- document common serialization/deserialization patterns
- describe available configuration options

## Testing
- `dotnet test` *(fails: ParseMetadata and related methods missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cf4786e88333b5da953078a42493