### PR TITLE
feat: add multi-target support

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,7 +14,9 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: |
+          8.0.x
+          6.0.x
         dotnet-quality: 'ga'
     - name: Restore dependencies
       run: |
@@ -27,7 +29,9 @@ jobs:
        dotnet build --no-restore --configuration Release ./SatisfactorySaveNet.Abstracts/SatisfactorySaveNet.Abstracts.csproj
        dotnet build --no-restore --configuration Debug ./SatisfactorySaveNet.Tests/SatisfactorySaveNet.Tests.csproj
     - name: Test
-      run: dotnet test --no-build --verbosity normal ./SatisfactorySaveNet.Tests/SatisfactorySaveNet.Tests.csproj
+      run: |
+       dotnet test --no-build --verbosity normal --framework net8.0 ./SatisfactorySaveNet.Tests/SatisfactorySaveNet.Tests.csproj
+       dotnet test --no-build --verbosity normal --framework net6.0 ./SatisfactorySaveNet.Tests/SatisfactorySaveNet.Tests.csproj
     - name: publish SatisfactorySaveNet.Abstracts on nuget.org
       id: publish_nuget1
       uses: alirezanet/publish-nuget@v3.1.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <Copyright>R3dByt3</Copyright>
         <Authors>R3dByt3</Authors>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net6.0;netstandard2.1</TargetFrameworks>
         <LangVersion>12.0</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>
@@ -25,6 +25,10 @@
 
     <ItemGroup>
         <None Include="$(ProjectDir)..\README.md" Pack="true" PackagePath="\" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'netstandard2.1'">
+        <Compile Include="$(MSBuildThisFileDirectory)Polyfills/RequiredMemberAttributes.cs" Link="RequiredMemberAttributes.cs" />
     </ItemGroup>
 
     <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,11 +7,11 @@
     <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="FluentAssertions" Version="8.6.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NUnit" Version="4.4.0" />
@@ -23,5 +23,8 @@
     <PackageVersion Include="Seq.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Serilog.Sinks.Seq" Version="8.0.0" />
     <PackageVersion Include="Ulid" Version="1.4.1" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Include="Castle.Core" Version="5.1.1" />
   </ItemGroup>
 </Project>

--- a/Polyfills/RequiredMemberAttributes.cs
+++ b/Polyfills/RequiredMemberAttributes.cs
@@ -1,0 +1,22 @@
+#if !NET7_0_OR_GREATER
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Event, AllowMultiple = false)]
+    public sealed class RequiredMemberAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed class SetsRequiredMembersAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
+    internal sealed class CompilerFeatureRequiredAttribute : Attribute
+    {
+        public string FeatureName { get; }
+        public bool IsOptional { get; set; }
+        public string? Language { get; set; }
+        public CompilerFeatureRequiredAttribute(string featureName)
+        {
+            FeatureName = featureName;
+        }
+    }
+}
+#endif

--- a/SatisfactorySaveNet.Abstracts/Maths/Matrix/Matrix4.cs
+++ b/SatisfactorySaveNet.Abstracts/Maths/Matrix/Matrix4.cs
@@ -1122,9 +1122,15 @@ namespace SatisfactorySaveNet.Abstracts.Maths.Matrix
                 throw new ArgumentOutOfRangeException(nameof(fovy));
             }
 
+#if NET7_0_OR_GREATER
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(aspect);
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(depthNear);
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(depthFar);
+#else
+            if (aspect <= 0) throw new ArgumentOutOfRangeException(nameof(aspect));
+            if (depthNear <= 0) throw new ArgumentOutOfRangeException(nameof(depthNear));
+            if (depthFar <= 0) throw new ArgumentOutOfRangeException(nameof(depthFar));
+#endif
 
             var maxY = depthNear * MathF.Tan(0.5f * fovy);
             var minY = -maxY;
@@ -1188,9 +1194,15 @@ namespace SatisfactorySaveNet.Abstracts.Maths.Matrix
             out Matrix4 result
         )
         {
+#if NET7_0_OR_GREATER
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(depthNear);
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(depthFar);
             ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(depthNear, depthFar);
+#else
+            if (depthNear <= 0) throw new ArgumentOutOfRangeException(nameof(depthNear));
+            if (depthFar <= 0) throw new ArgumentOutOfRangeException(nameof(depthFar));
+            if (depthNear >= depthFar) throw new ArgumentOutOfRangeException(nameof(depthNear));
+#endif
 
             var x = 2.0f * depthNear / (right - left);
             var y = 2.0f * depthNear / (top - bottom);

--- a/SatisfactorySaveNet.Abstracts/Maths/Matrix/Matrix4D.cs
+++ b/SatisfactorySaveNet.Abstracts/Maths/Matrix/Matrix4D.cs
@@ -925,9 +925,15 @@ namespace SatisfactorySaveNet.Abstracts.Maths.Matrix
                 throw new ArgumentOutOfRangeException(nameof(fovy));
             }
 
+#if NET7_0_OR_GREATER
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(aspect);
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(depthNear);
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(depthFar);
+#else
+            if (aspect <= 0) throw new ArgumentOutOfRangeException(nameof(aspect));
+            if (depthNear <= 0) throw new ArgumentOutOfRangeException(nameof(depthNear));
+            if (depthFar <= 0) throw new ArgumentOutOfRangeException(nameof(depthFar));
+#endif
 
             var maxY = depthNear * Math.Tan(0.5 * fovy);
             var minY = -maxY;
@@ -991,9 +997,15 @@ namespace SatisfactorySaveNet.Abstracts.Maths.Matrix
             out Matrix4D result
         )
         {
+#if NET7_0_OR_GREATER
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(depthNear);
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(depthFar);
             ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(depthNear, depthFar);
+#else
+            if (depthNear <= 0) throw new ArgumentOutOfRangeException(nameof(depthNear));
+            if (depthFar <= 0) throw new ArgumentOutOfRangeException(nameof(depthFar));
+            if (depthNear >= depthFar) throw new ArgumentOutOfRangeException(nameof(depthNear));
+#endif
 
             var x = 2.0 * depthNear / (right - left);
             var y = 2.0 * depthNear / (top - bottom);

--- a/SatisfactorySaveNet.Abstracts/SatisfactorySaveNet.Abstracts.csproj
+++ b/SatisfactorySaveNet.Abstracts/SatisfactorySaveNet.Abstracts.csproj
@@ -19,13 +19,17 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Remove="Math\**" />
-    <EmbeddedResource Remove="Math\**" />
-    <None Remove="Math\**" />
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>SatisfactorySaveNet</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
+    <ItemGroup>
+      <Compile Remove="Math\**" />
+      <EmbeddedResource Remove="Math\**" />
+      <None Remove="Math\**" />
+      <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+        <_Parameter1>SatisfactorySaveNet</_Parameter1>
+      </AssemblyAttribute>
+    </ItemGroup>
 
-</Project>
+    <ItemGroup>
+      <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
+    </ItemGroup>
+
+  </Project>

--- a/SatisfactorySaveNet.Benchmarks/SatisfactorySaveNet.Benchmarks.csproj
+++ b/SatisfactorySaveNet.Benchmarks/SatisfactorySaveNet.Benchmarks.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/SatisfactorySaveNet.Tests/SatisfactorySaveNet.Tests.csproj
+++ b/SatisfactorySaveNet.Tests/SatisfactorySaveNet.Tests.csproj
@@ -1,8 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <SuppressTfmSupportBuildErrors>true</SuppressTfmSupportBuildErrors>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -30,6 +33,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Seq.Extensions.Logging" />
+    <PackageReference Include="Castle.Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SatisfactorySaveNet/SatisfactorySaveNet.csproj
+++ b/SatisfactorySaveNet/SatisfactorySaveNet.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
     <PackageReference Include="Ulid" />
+    <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 
   <ItemGroup>
@@ -31,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(OutputPath)$(AssemblyName).xml" Pack="true" PackagePath="" />
+    <None Include="$(DocumentationFile)" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/SatisfactorySaveNet/SaveFileSerializer.cs
+++ b/SatisfactorySaveNet/SaveFileSerializer.cs
@@ -5,6 +5,11 @@ using SatisfactorySaveNet.Abstracts.Model;
 using System;
 using System.IO;
 using System.IO.Compression;
+#if NET7_0_OR_GREATER
+using CompressionStream = System.IO.Compression.ZLibStream;
+#else
+using CompressionStream = System.IO.Compression.DeflateStream;
+#endif
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -45,9 +50,15 @@ public class SaveFileSerializer : ISaveFileSerializer
     /// <param name="bodySerializer">Serializer for the save file body.</param>
     public SaveFileSerializer(IHeaderSerializer headerSerializer, IChunkSerializer chunkSerializer, IBodySerializer bodySerializer)
     {
+#if NET7_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(headerSerializer);
         ArgumentNullException.ThrowIfNull(chunkSerializer);
         ArgumentNullException.ThrowIfNull(bodySerializer);
+#else
+        if (headerSerializer is null) throw new ArgumentNullException(nameof(headerSerializer));
+        if (chunkSerializer is null) throw new ArgumentNullException(nameof(chunkSerializer));
+        if (bodySerializer is null) throw new ArgumentNullException(nameof(bodySerializer));
+#endif
 
         _headerSerializer = headerSerializer;
         _chunkSerializer = chunkSerializer;
@@ -242,7 +253,7 @@ public class SaveFileSerializer : ISaveFileSerializer
                 await CopyExactAsync(stream, chunk, summary.CompressedSize, async, cancellationToken).ConfigureAwait(false);
                 chunk.Position = 0;
 
-                using (var zStream = new ZLibStream(chunk, CompressionMode.Decompress, true))
+                using (var zStream = new CompressionStream(chunk, CompressionMode.Decompress, true))
                 {
                     await CopyToAsync(zStream, buffer, async, cancellationToken).ConfigureAwait(false);
                 }
@@ -331,7 +342,7 @@ public class SaveFileSerializer : ISaveFileSerializer
             var read = buffer.Read(chunkBuffer, 0, chunkBuffer.Length);
 
             using var compressed = Manager.GetStream();
-            using (var zStream = new ZLibStream(compressed, CompressionMode.Compress, true))
+            using (var zStream = new CompressionStream(compressed, CompressionMode.Compress, true))
             {
                 await WriteAsync(zStream, chunkBuffer, 0, read, async, cancellationToken).ConfigureAwait(false);
             }
@@ -396,7 +407,7 @@ public class SaveFileSerializer : ISaveFileSerializer
         if (async)
             return stream.WriteAsync(buffer.AsMemory(offset, count), cancellationToken);
         stream.Write(buffer, offset, count);
-        return ValueTask.CompletedTask;
+        return GetCompletedValueTask();
     }
 
     private static ValueTask CopyToAsync(Stream source, Stream destination, bool async, CancellationToken cancellationToken)
@@ -404,7 +415,16 @@ public class SaveFileSerializer : ISaveFileSerializer
         if (async)
             return new ValueTask(source.CopyToAsync(destination, cancellationToken));
         source.CopyTo(destination);
+        return GetCompletedValueTask();
+    }
+
+    private static ValueTask GetCompletedValueTask()
+    {
+#if NETSTANDARD2_1
+        return default;
+#else
         return ValueTask.CompletedTask;
+#endif
     }
 
     private static async ValueTask ReadExactlyAsync(Stream stream, byte[] buffer, int count, bool async, CancellationToken cancellationToken)

--- a/SatisfactorySaveNet/StringSerializer.cs
+++ b/SatisfactorySaveNet/StringSerializer.cs
@@ -22,11 +22,19 @@ public class StringSerializer : IStringSerializer
     public string Deserialize(BinaryReader reader)
     {
         Span<char> chars = ReadCharArray(reader);
+#if NET7_0_OR_GREATER
         var result = StringPool.Shared.GetOrAdd(chars.TrimEnd('\0'));
+#else
+        var result = StringPool.Shared.GetOrAdd(new string(chars.ToArray()).TrimEnd('\0'));
+#endif
 #if DEBUG
         var sf1 = new System.Diagnostics.StackTrace(true).GetFrame(1)!;
         var sf2 = new System.Diagnostics.StackTrace(true).GetFrame(2)!;
+#if NET7_0_OR_GREATER
         _logger.LogInformation("DeserializeString {Value} - IsASCII {IsASCII} - File {File1} - Line {Line1} - File {File2} - Line {Line2}", result, result.All(char.IsAscii), sf1.GetFileName(), sf1.GetFileLineNumber(), sf2.GetFileName(), sf2.GetFileLineNumber());
+#else
+        _logger.LogInformation("DeserializeString {Value} - IsASCII {IsASCII} - File {File1} - Line {Line1} - File {File2} - Line {Line2}", result, result.All(c => c <= 127), sf1.GetFileName(), sf1.GetFileLineNumber(), sf2.GetFileName(), sf2.GetFileLineNumber());
+#endif
 #endif
         return result;
     }
@@ -35,7 +43,11 @@ public class StringSerializer : IStringSerializer
     {
         // Strings in save files are stored with a length prefix including the terminating null.
         // Positive length indicates UTF-8, negative length indicates UTF-16.
+#if NET7_0_OR_GREATER
         var isAscii = value.All(char.IsAscii);
+#else
+        var isAscii = value.All(c => c <= 127);
+#endif
         var terminated = value + '\0';
         if (isAscii)
         {


### PR DESCRIPTION
## Summary
- multi-target all projects for net8.0, net6.0, and netstandard2.1
- add compatibility polyfills and conditional code for older frameworks
- build and test all target frameworks in CI

## Testing
- `dotnet build SatisfactorySaveNet.sln -c Release`
- `dotnet test SatisfactorySaveNet.Tests/SatisfactorySaveNet.Tests.csproj -c Release -f net8.0`
- `dotnet test SatisfactorySaveNet.Tests/SatisfactorySaveNet.Tests.csproj -c Release -f net6.0` *(fails: Castle.Core.dll missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e2ddfeb88333be2e58286afa80e5