### PR TITLE
Add build 1.0 constant and update tests

### DIFF
--- a/SatisfactorySaveNet.Abstracts/BuildVersions.cs
+++ b/SatisfactorySaveNet.Abstracts/BuildVersions.cs
@@ -22,11 +22,17 @@ public static class BuildVersions
     /// </summary>
     public const int Patch0700 = 208250;
 
+    /// <summary>
+    /// Release build for Version 1.0.
+    /// </summary>
+    public const int Patch1000 = 424353;
+
     private static readonly IReadOnlyDictionary<int, string> _names = new Dictionary<int, string>
     {
         [Patch0400] = "Update 4 (0.4.0.0)",
         [Patch0613] = "Patch 0.6.1.3",
-        [Patch0700] = "Patch 0.7.0.0"
+        [Patch0700] = "Patch 0.7.0.0",
+        [Patch1000] = "Patch 1.0.0.0"
     };
 
     /// <summary>

--- a/SatisfactorySaveNet.Tests/BodySerializerTests.cs
+++ b/SatisfactorySaveNet.Tests/BodySerializerTests.cs
@@ -22,7 +22,7 @@ public class BodySerializerTests
         {
             HeaderVersion = 5,
             SaveVersion = 10,
-            BuildVersion = BuildVersions.Patch0613,
+            BuildVersion = BuildVersions.Patch1000,
             MapName = "Map",
             MapOptions = string.Empty,
             SessionName = "Session",
@@ -89,7 +89,7 @@ public class BodySerializerTests
         {
             HeaderVersion = 7,
             SaveVersion = 41,
-            BuildVersion = BuildVersions.Patch0613,
+            BuildVersion = BuildVersions.Patch1000,
             MapName = "Map",
             MapOptions = string.Empty,
             SessionName = "Session",
@@ -134,7 +134,7 @@ public class BodySerializerTests
         {
             HeaderVersion = 7,
             SaveVersion = 41,
-            BuildVersion = BuildVersions.Patch0613,
+            BuildVersion = BuildVersions.Patch1000,
             MapName = "Map",
             MapOptions = string.Empty,
             SessionName = "Session",
@@ -188,7 +188,7 @@ public class BodySerializerTests
         {
             HeaderVersion = 7,
             SaveVersion = 51,
-            BuildVersion = BuildVersions.Patch0613,
+            BuildVersion = BuildVersions.Patch1000,
             MapName = "Map",
             MapOptions = string.Empty,
             SessionName = "Session",

--- a/SatisfactorySaveNet.Tests/BuildVersionsTests.cs
+++ b/SatisfactorySaveNet.Tests/BuildVersionsTests.cs
@@ -1,0 +1,18 @@
+using FluentAssertions;
+using NUnit.Framework;
+using SatisfactorySaveNet.Abstracts;
+
+namespace SatisfactorySaveNet.Tests;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class BuildVersionsTests
+{
+    [Test]
+    public void IsKnown_ReturnsTrue_ForPatch1000()
+    {
+        BuildVersions.IsKnown(BuildVersions.Patch1000).Should().BeTrue();
+        BuildVersions.GetName(BuildVersions.Patch1000).Should().Be("Patch 1.0.0.0");
+    }
+}
+

--- a/SatisfactorySaveNet.Tests/HeaderSerializerTests.cs
+++ b/SatisfactorySaveNet.Tests/HeaderSerializerTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using FluentAssertions;
 using SatisfactorySaveNet.Abstracts;
 using SatisfactorySaveNet.Abstracts.Model;
+using SatisfactorySaveNet;
 
 namespace SatisfactorySaveNet.Tests;
 
@@ -17,7 +18,7 @@ public class HeaderSerializerTests
         {
             HeaderVersion = (int)SaveHeaderVersion.VersionPlusOne,
             SaveVersion = (int)FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents,
-            BuildVersion = BuildVersions.Patch0613,
+            BuildVersion = BuildVersions.Patch1000,
             SaveName = string.Empty,
             MapName = string.Empty,
             MapOptions = string.Empty,
@@ -54,7 +55,7 @@ public class HeaderSerializerTests
         {
             HeaderVersion = (int)SaveHeaderVersion.VersionPlusOne - 1,
             SaveVersion = (int)FSaveCustomVersion.VersionPlusOne,
-            BuildVersion = BuildVersions.Patch0613,
+            BuildVersion = BuildVersions.Patch1000,
             SaveName = string.Empty,
             MapName = string.Empty,
             MapOptions = string.Empty,
@@ -100,5 +101,27 @@ public class HeaderSerializerTests
 
         Action act = () => HeaderSerializer.Instance.Deserialize(reader);
         act.Should().Throw<NotSupportedException>().WithMessage("*build version*");
+    }
+
+    [Test]
+    public void Deserialize_DoesNotThrow_ForKnownBuildVersion()
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true))
+        {
+            writer.Write((int)SaveHeaderVersion.InitialVersion);
+            writer.Write((int)FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents);
+            writer.Write(BuildVersions.Patch1000);
+            StringSerializer.Instance.Serialize(writer, string.Empty);
+            StringSerializer.Instance.Serialize(writer, string.Empty);
+            StringSerializer.Instance.Serialize(writer, string.Empty);
+            writer.Write(0);
+            writer.Write(DateTime.UnixEpoch.Ticks);
+        }
+
+        stream.Position = 0;
+        using var reader = new BinaryReader(stream);
+        Action act = () => HeaderSerializer.Instance.Deserialize(reader);
+        act.Should().NotThrow();
     }
 }

--- a/SatisfactorySaveNet.Tests/SaveFileSerializerCompressedTests.cs
+++ b/SatisfactorySaveNet.Tests/SaveFileSerializerCompressedTests.cs
@@ -21,7 +21,7 @@ public class SaveFileSerializerCompressedTests
         {
             HeaderVersion = 5,
             SaveVersion = 21,
-            BuildVersion = BuildVersions.Patch0613,
+            BuildVersion = BuildVersions.Patch1000,
             MapName = "Map",
             MapOptions = string.Empty,
             SessionName = "Session",

--- a/SatisfactorySaveNet.Tests/SaveSerializerTests.cs
+++ b/SatisfactorySaveNet.Tests/SaveSerializerTests.cs
@@ -24,7 +24,7 @@ public class SaveSerializerTests
             {
                 HeaderVersion = 5,
                 SaveVersion = (int)FSaveCustomVersion.DROPPED_WireSpanFromConnnectionComponents,
-                BuildVersion = BuildVersions.Patch0613,
+                BuildVersion = BuildVersions.Patch1000,
                 SaveName = "Test",
                 MapName = "Map",
                 MapOptions = string.Empty,
@@ -63,7 +63,7 @@ public class SaveSerializerTests
             {
                 HeaderVersion = 5,
                 SaveVersion = 21,
-                BuildVersion = BuildVersions.Patch0613,
+                BuildVersion = BuildVersions.Patch1000,
                 SaveName = "Test",
                 MapName = "Map",
                 MapOptions = string.Empty,
@@ -100,7 +100,7 @@ public class SaveSerializerTests
             {
                 HeaderVersion = 5,
                 SaveVersion = 21,
-                BuildVersion = BuildVersions.Patch0613,
+                BuildVersion = BuildVersions.Patch1000,
                 SaveName = "Test",
                 MapName = "Map",
                 MapOptions = string.Empty,
@@ -130,7 +130,7 @@ public class SaveSerializerTests
             {
                 HeaderVersion = 5,
                 SaveVersion = 21,
-                BuildVersion = BuildVersions.Patch0613,
+                BuildVersion = BuildVersions.Patch1000,
                 SaveName = "Test",
                 MapName = "Map",
                 MapOptions = string.Empty,
@@ -182,7 +182,7 @@ public class SaveSerializerTests
             {
                 HeaderVersion = 5,
                 SaveVersion = 21,
-                BuildVersion = BuildVersions.Patch0613,
+                BuildVersion = BuildVersions.Patch1000,
                 SaveName = "Test",
                 MapName = "Map",
                 MapOptions = string.Empty,
@@ -223,7 +223,7 @@ public class SaveSerializerTests
             {
                 HeaderVersion = 5,
                 SaveVersion = 21,
-                BuildVersion = BuildVersions.Patch0613,
+                BuildVersion = BuildVersions.Patch1000,
                 SaveName = "Test",
                 MapName = "Map",
                 MapOptions = string.Empty,

--- a/SatisfactorySaveNet.Tests/SaveVersion51Tests.cs
+++ b/SatisfactorySaveNet.Tests/SaveVersion51Tests.cs
@@ -19,7 +19,7 @@ public class SaveVersion51Tests
         {
             HeaderVersion = 14,
             SaveVersion = 51,
-            BuildVersion = BuildVersions.Patch0613,
+            BuildVersion = BuildVersions.Patch1000,
             SaveName = "TestSave",
             MapName = "Map",
             MapOptions = "options",
@@ -65,7 +65,7 @@ public class SaveVersion51Tests
             {
                 HeaderVersion = 14,
                 SaveVersion = 51,
-                BuildVersion = BuildVersions.Patch0613,
+                BuildVersion = BuildVersions.Patch1000,
                 SaveName = "TestSave",
                 MapName = "Map",
                 MapOptions = string.Empty,

--- a/SatisfactorySaveNet.Tests/SaveVersion52PlusTests.cs
+++ b/SatisfactorySaveNet.Tests/SaveVersion52PlusTests.cs
@@ -8,8 +8,8 @@ using SatisfactorySaveNet.Abstracts.Model;
 
 namespace SatisfactorySaveNet.Tests;
 
-[TestFixture(52, BuildVersions.Patch0700)]
-[TestFixture(53, BuildVersions.Patch0700)]
+[TestFixture(52, BuildVersions.Patch1000)]
+[TestFixture(53, BuildVersions.Patch1000)]
 [Parallelizable(ParallelScope.All)]
 public class SaveVersion52PlusTests
 {


### PR DESCRIPTION
## Summary
- add new Patch1000 build constant with friendly name
- update tests to use Patch1000 and cover BuildVersions and header deserialization

## Testing
- `dotnet test --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_68a4018176648333a5d03b0924555866