### PR TITLE
Add async roundtrip test for save files

### DIFF
--- a/SatisfactorySaveNet.Tests/LatestSaveRoundtripTests.cs
+++ b/SatisfactorySaveNet.Tests/LatestSaveRoundtripTests.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using NUnit.Framework;
 using SatisfactorySaveNet;
@@ -28,6 +30,20 @@ public class LatestSaveRoundtripTests
 
         var roundtripData = SaveFileSerializer.Instance.Serialize(originalSave);
         var roundtripped = SaveFileSerializer.Instance.Deserialize(roundtripData);
+
+        roundtripped.Header.Should().BeEquivalentTo(originalSave.Header);
+        roundtripped.Header.SaveName.Should().Be(originalSave.Header.SaveName);
+        roundtripped.Header.IsCreativeModeEnabled.Should().Be(originalSave.Header.IsCreativeModeEnabled);
+        roundtripped.Body.Should().BeEquivalentTo(originalSave.Body);
+    }
+
+    [TestCaseSource(nameof(SaveFiles))]
+    public async Task Save_Roundtrips_Correctly_Async(string path)
+    {
+        var originalSave = await SaveFileSerializer.Instance.DeserializeAsync(path, CancellationToken.None);
+
+        var roundtripData = await SaveFileSerializer.Instance.SerializeAsync(originalSave, CancellationToken.None);
+        var roundtripped = await SaveFileSerializer.Instance.DeserializeAsync(roundtripData, CancellationToken.None);
 
         roundtripped.Header.Should().BeEquivalentTo(originalSave.Header);
         roundtripped.Header.SaveName.Should().Be(originalSave.Header.SaveName);


### PR DESCRIPTION
## Summary
- add asynchronous roundtrip test exercising `DeserializeAsync` and `SerializeAsync` on sample saves

## Testing
- `dotnet test` *(fails: EndOfStreamException on sample saves and missing .NET 6 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68a4926437fc83338abbac49debb7e12