### PR TITLE
Allow newer .NET SDK versions

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.119",
-    "rollForward": "feature"
+    "version": "8.0.100",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
## Summary
- relax global.json to use .NET SDK 8.0.100 and allow latest feature roll-forward

## Testing
- `dotnet build`
- `dotnet test` *(fails: requires Microsoft.NETCore.App 6.0.0, 4 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c04369308333be218bebaaec6685